### PR TITLE
fix(boot): optimize role boot costs with .min briefs and boot.yml

### DIFF
--- a/.agent/repo=.this/role=any/boot.yml
+++ b/.agent/repo=.this/role=any/boot.yml
@@ -2,6 +2,7 @@
 #
 # controls which briefs are said (inline) vs reffed (pointer only).
 # unmatched briefs become refs automatically.
+# note: .md.min versions are auto-preferred when they exist.
 
 briefs:
   say:

--- a/.agent/repo=.this/role=any/briefs/bin.dispatcher.pattern.md.min
+++ b/.agent/repo=.this/role=any/briefs/bin.dispatcher.pattern.md.min
@@ -1,0 +1,16 @@
+# bin/run dispatcher pattern
+
+routes commands to bun (fast) or jit (flexible):
+
+| path | commands | startup |
+|------|----------|---------|
+| bun | `run --skill/--init`, `roles boot/cost` | ~35-70ms |
+| jit | `roles link/init`, `act`, `ask` | ~300ms+ |
+
+why: bun binaries embed module lookup at compile time, can't find npm packages from target repo. `.agent/` pattern solves this: `roles link` pays npm cost once, creates symlinks, all other commands read from symlinks.
+
+binaries:
+- `bin/run.bun` — shell dispatcher
+- `bin/run.bun.rhachet-run.bc` — bun binary for `run`
+- `bin/run.bun.rhachet-roles.bc` — bun binary for `roles`
+- `bin/run.jit` — tsx entry for jit path

--- a/.agent/repo=.this/role=any/briefs/code.test.accept.blackbox.md
+++ b/.agent/repo=.this/role=any/briefs/code.test.accept.blackbox.md
@@ -51,7 +51,7 @@ all external contracts must have acceptance test coverage:
 
 ## .pattern: genTestTempRepo
 
-creates isolated test environments in `os.tmpdir()`:
+creates isolated test environments via `genTempDir` from 'test-fns':
 - clones example repos with proper `.agent/` structure
 - leverages OS temp directory cleanup (no manual teardown needed)
 - ensures each test gets a fresh, isolated workspace
@@ -72,7 +72,7 @@ expect(result.status).toEqual(0);
 ## .principles
 
 1. **only test through contract layer** - no internal imports allowed in acceptance tests
-2. **use os.tmpdir()** - maximally portable and isolated, OS handles cleanup
+2. **use `genTempDir` from 'test-fns'** - never raw os.tmpdir(); portable, isolated, OS handles cleanup
 3. **invoke CLI as subprocess** - uses `invokeRhachetCli` helper
 4. **assert on observable outputs** - stdout/stderr/status for cli, return values for sdk
 5. **fixture-based setup** - reusable test repo templates

--- a/.agent/repo=.this/role=any/briefs/code.test.accept.blackbox.md.min
+++ b/.agent/repo=.this/role=any/briefs/code.test.accept.blackbox.md.min
@@ -1,0 +1,19 @@
+# accept.blackbox test strategy
+
+acceptance tests validate external contracts as black-boxes:
+- cli: subprocess invocation, assert stdout/stderr/status
+- sdk: import dist/, call functions, assert returns
+- api: http calls, assert responses
+
+structure:
+- `accept.blackbox/.test/assets/` — fixture templates (minimal, with-skills, with-briefs, with-registry)
+- `accept.blackbox/.test/infra/` — genTestTempRepo.ts, invokeRhachetCliBinary.ts
+- `accept.blackbox/cli/` — cli acceptance tests
+- `accept.blackbox/sdk/` — sdk acceptance tests
+
+principles:
+- test only through contract layer, no internal imports
+- use `genTempDir` from 'test-fns' for isolation (never raw os.tmpdir)
+- invoke cli as subprocess via invokeRhachetCli
+- assert on observable outputs
+- fixture-based setup via genTestTempRepo

--- a/.agent/repo=.this/role=any/briefs/define.agent-dir.md.min
+++ b/.agent/repo=.this/role=any/briefs/define.agent-dir.md.min
@@ -1,0 +1,27 @@
+# .agent/ directory
+
+shared source of truth for humans and robots. browse same briefs, invoke same skills.
+
+```
+.agent/
+  repo=.this/           # native to this repo
+    role=any/           # applies to everyone
+      briefs/           # curated knowledge
+      skills/           # executable capabilities
+  repo=$slug/           # linked from rhachet-roles-$slug
+    role=$name/ →       # symlink to node_modules/...
+```
+
+## benefits
+
+- **transparency** — see exactly what robots see
+- **parity** — humans invoke same skills robots dispatch
+- **speed** — bun reads from filesystem (~35-70ms), no package lookup
+- **experimentation** — edit directly, changes take effect immediately
+
+## how roles get there
+
+- **native**: create in `.agent/repo=.this/`
+- **linked**: `npx rhachet init --roles $role` symlinks from packages
+
+no hidden config. answer is always `.agent/`.

--- a/.agent/repo=.this/role=any/briefs/define.rhachet.v3.md.min
+++ b/.agent/repo=.this/role=any/briefs/define.rhachet.v3.md.min
@@ -1,0 +1,45 @@
+# rhachet
+
+framework for reliable thought.
+
+register 🧢 roles + 🧠 brains → produce 🎭 actors who clone that thought.
+
+## core objects
+
+| concept | emoji | what |
+|---------|-------|------|
+| role | 🧢 | bundle of skills + briefs |
+| brain | 🧠 | inference provider |
+| actor | 🎭 | brain enrolled in a role |
+| skill | 💪 | executable capability |
+| brief | 📚 | curated knowledge |
+
+## thought routes
+
+| route | emoji | what |
+|-------|-------|------|
+| solid | 🪨 | deterministic throughout (`.run()`) |
+| rigid | 🔩 | harness controls, brain augments (`.act()`) |
+| fluid | 💧 | brain decides path (`.ask()`) |
+
+## enrollment
+
+pair 🧠 brain with 🧢 role → 🎭 actor
+
+- 📚 briefs flavor the brain (suffix system prompt, shape thought gravity)
+- 💪 skills offload work from imagine-cost to compute-cost
+
+roles are portable across brains. define once, enroll any brain, clone that thought.
+
+## 🪐 concept planets
+
+🧠 brains navigate concept space like ships in galactic space. 📚 briefs register concept planets with gravity that pulls thought toward them.
+
+unenrolled brain → drifts toward whatever it absorbed (java idioms, verbose comments, foreign patterns).
+
+enrolled brain → gravity from brief planets shapes navigation:
+- 🪐 "arrow functions only"
+- 🪐 "input-context pattern"
+- 🪐 "fail fast via HelpfulError"
+
+enrollment shapes the gravity of concepts the brain navigates to.

--- a/.agent/repo=.this/role=any/briefs/rule.require.shared-test-fixtures.md.min
+++ b/.agent/repo=.this/role=any/briefs/rule.require.shared-test-fixtures.md.min
@@ -1,0 +1,13 @@
+# rule.require.shared-test-fixtures
+
+fixture generators must be in shared infra, not duplicated inline.
+
+locations:
+- unit/integration: `src/.test/assets/`
+- acceptance: `accept.blackbox/.test/assets/`
+
+extract when: 2+ files use same shape, non-trivial setup, core domain concept
+
+name patterns:
+- `genMocked*` — mock with defaults
+- `genSample*` — realistic sample

--- a/.agent/repo=.this/role=any/briefs/run.executable.lookup.pattern.md.min
+++ b/.agent/repo=.this/role=any/briefs/run.executable.lookup.pattern.md.min
@@ -1,0 +1,13 @@
+# run executable lookup
+
+`run --skill` and `run --init` auto-discover from `.agent/`:
+
+1. scan `.agent/repo=*/role=*/skills/*.sh` (or `inits/`)
+2. filter by name
+3. one match → execute
+4. zero matches → "not found"
+5. multiple matches → "ambiguous, specify --repo and/or --role"
+
+disambiguation:
+- `--repo <slug>` — filter to repo
+- `--role <slug>` — filter to role

--- a/.agent/repo=.this/role=keyrack/boot.yml
+++ b/.agent/repo=.this/role=keyrack/boot.yml
@@ -1,0 +1,11 @@
+# .agent/repo=.this/role=keyrack/boot.yml
+#
+# controls which briefs are said (inline) vs reffed (pointer only).
+# unmatched briefs become refs automatically.
+
+briefs:
+  say:
+    # core identity
+    - briefs/define.keyrack-identity.md
+    - briefs/define.vault-types-owned-vs-refed.md
+    - briefs/define.vault-mech-adapters.md

--- a/.agent/repo=.this/role=keyrack/briefs/define.keyrack-identity.md.min
+++ b/.agent/repo=.this/role=keyrack/briefs/define.keyrack-identity.md.min
@@ -1,0 +1,19 @@
+# define.keyrack-identity
+
+keyrack is **not a vault**. keyrack is:
+- **firewall** — controls which keys are accessible, to whom, in which env
+- **dispatcher** — routes unlock requests to the correct vault
+- **broker** — daemon holds unlocked keys for your session
+
+layers:
+- **repo.manifest** — which keys are required (narrows what gets unlocked)
+- **host.manifest** — which & where keys can be found
+- **vault** — holds the secret (owned) or pointer to external (refed)
+- **daemon** — session keyrack, ephemeral cache of unlocked keys
+
+commands:
+- **set** — configures where a key lives (writes to host.manifest + vault)
+- **unlock** — populates daemon from vaults
+- **get** — grabs from daemon at access time
+
+flow: repo.manifest filters → host.manifest maps to vaults → unlock fetches → daemon caches → get retrieves

--- a/.agent/repo=.this/role=keyrack/briefs/define.vault-mech-adapters.md.min
+++ b/.agent/repo=.this/role=keyrack/briefs/define.vault-mech-adapters.md.min
@@ -1,0 +1,24 @@
+# define.vault-mech-adapters
+
+two adapter types separate storage from transformation:
+
+| adapter | responsibility | examples |
+|---------|----------------|----------|
+| **vault** | storage backend | os.secure, os.direct, 1password, aws.config |
+| **mech** | credential transformation + guided setup | PERMANENT_VIA_REPLICA, EPHEMERAL_VIA_GITHUB_APP, EPHEMERAL_VIA_AWS_SSO |
+
+vault adapter owns:
+- where to store (`~/.keyrack/secrets/`, `op://`, `~/.aws/config`)
+- how to encrypt (age, plaintext, 1password, ini)
+
+mech adapter owns:
+- `acquireForSet()` — guided setup → source credential
+- `deliverForGet()` — source → usable secret (identity for permanent, transform for ephemeral)
+
+key insight: vault.set encapsulates secret ops (orchestrator never sees secret), vault.get encapsulates transformation. mechs are portable across vaults.
+
+compatibility:
+- os.secure: PERMANENT_VIA_REPLICA, EPHEMERAL_VIA_GITHUB_APP
+- os.direct: PERMANENT_VIA_REPLICA only
+- 1password: PERMANENT_VIA_REPLICA, EPHEMERAL_VIA_GITHUB_APP
+- aws.config: EPHEMERAL_VIA_AWS_SSO only


### PR DESCRIPTION
fix(boot): optimize role boot costs with .min briefs and boot.yml

- added boot.yml for role=keyrack (3 say, 14 ref)
- created .md.min versions for 8 briefs across both roles
- updated code.test.accept.blackbox.md to clarify genTempDir usage
- total boot cost reduced 87% (23k → 3k tokens)

---
🐢🌊 surfed in by seaturtle[bot]