### PR TITLE
fix(keyrack): handle signed/unsigned socket inode mismatch and add --env status filter

### DIFF
--- a/.agent/repo=.this/role=keyrack/briefs/howto.diagnose-daemon-errors.md
+++ b/.agent/repo=.this/role=keyrack/briefs/howto.diagnose-daemon-errors.md
@@ -1,0 +1,143 @@
+# howto.diagnose-daemon-errors
+
+## .what
+
+guide to diagnose keyrack daemon errors and test fixes locally.
+
+## .key insight: daemon runs compiled code from dist/
+
+the daemon is spawned via `node -e` with a require from `dist/`, not `src/`.
+
+```
+node -e 'require("/path/to/dist/.../startKeyrackDaemon.js")'
+```
+
+**implication**: a patch to TypeScript in `src/` does NOT affect a live daemon. you must:
+1. rebuild: `npm run build`
+2. prune daemon: `npx rhachet keyrack daemon prune --owner $owner`
+3. next command spawns fresh daemon with new code
+
+## .diagnose: which daemon is active
+
+### find daemon artifacts
+
+socket and PID files live in `$XDG_RUNTIME_DIR` (usually `/run/user/$UID`):
+
+```
+/run/user/1000/keyrack.$SESSION.$HOMEHASH.$owner.sock
+/run/user/1000/keyrack.$SESSION.$HOMEHASH.$owner.pid
+```
+
+where:
+- `$SESSION` = login session id (from `/proc/$PID/sessionid`)
+- `$HOMEHASH` = first 8 chars of sha256 of `$HOME` realpath
+- `$owner` = keyrack owner (e.g., `ehmpath`)
+
+### compute home hash
+
+```bash
+printf '/home/vlad' | sha256sum | head -c 8
+# → 83db27ef
+```
+
+### find daemon PID
+
+```bash
+cat /run/user/1000/keyrack.4.83db27ef.ehmpath.pid
+# → 687954
+```
+
+### verify daemon is alive
+
+```bash
+cat /proc/687954/cmdline
+# shows node command with startKeyrackDaemon require path
+```
+
+### check which code daemon uses
+
+the cmdline shows the require path:
+- global: `/home/.../.pnpm/global/.../rhachet@x.y.z/dist/...`
+- local: `/home/.../your-worktree/dist/...`
+
+## .diagnose: ss lookup failures
+
+### symptom
+
+```
+UnexpectedCodePathError: no ss output for socket inode
+{ "inode": "2367234854" }
+```
+
+### root cause: signed vs unsigned integer mismatch
+
+`/proc/self/fd/$fd` shows inode as **unsigned** (e.g., `2367234854`).
+`ss -xp` shows inode as **signed 32-bit** (e.g., `-1927732442`).
+
+when inode > 2^31, they differ. grep for unsigned never finds signed.
+
+### verify with ss output
+
+```bash
+ss -xp | head -50
+```
+
+look for socket identifiers. negative numbers like `-1929414262` are signed representations of high inodes.
+
+### the math
+
+```
+unsigned_inode = 2367234854
+signed_inode = 2367234854 - 4294967296 = -1927732442
+```
+
+## .test fixes locally
+
+### 1. patch source in src/
+
+edit the TypeScript file (e.g., `src/.../getSocketPeerPid.ts`).
+
+### 2. rebuild
+
+```bash
+npm run build
+```
+
+### 3. prune extant daemon
+
+```bash
+npx rhachet keyrack daemon prune --owner ehmpath
+```
+
+**important**: use `npx rhachet`, not `rhx`. `rhx` may use global code.
+
+### 4. test with local code
+
+```bash
+npx rhachet keyrack unlock --owner ehmpath --env test
+npx rhachet keyrack status --owner ehmpath
+```
+
+a new daemon spawns from local `dist/` with your fix.
+
+### 5. verify daemon uses local code
+
+```bash
+cat /proc/$NEW_PID/cmdline
+```
+
+confirm require path points to your worktree, not global pnpm.
+
+## .common pitfalls
+
+| pitfall | symptom | fix |
+|---------|---------|-----|
+| patch src but not rebuild | fix doesn't take effect | `npm run build` |
+| use `rhx` instead of `npx rhachet` | may use global code | use `npx rhachet` |
+| daemon still uses old code | fix doesn't take effect | prune daemon first |
+| test global instead of local | fix works locally but not globally | check cmdline require path |
+
+## .see also
+
+- `spec.daemon-prune-behavior.md` — prune command specification
+- `refs/poc.root-cause-investigation.md` — signed/unsigned mismatch details

--- a/.behavior/v2026_04_16.fix-keyrack-failure/.bind/vlad.fix-keyrack-failure.flag
+++ b/.behavior/v2026_04_16.fix-keyrack-failure/.bind/vlad.fix-keyrack-failure.flag
@@ -1,0 +1,2 @@
+branch: vlad/fix-keyrack-failure
+bound_by: init.behavior skill

--- a/.behavior/v2026_04_16.fix-keyrack-failure/.route/.bind.vlad.fix-keyrack-failure.flag
+++ b/.behavior/v2026_04_16.fix-keyrack-failure/.route/.bind.vlad.fix-keyrack-failure.flag
@@ -1,0 +1,2 @@
+branch: vlad/fix-keyrack-failure
+bound_by: route.bind skill

--- a/.behavior/v2026_04_16.fix-keyrack-failure/.route/.gitignore
+++ b/.behavior/v2026_04_16.fix-keyrack-failure/.route/.gitignore
@@ -1,0 +1,5 @@
+# ignore all except passage.jsonl and .bind flags
+*
+!.gitignore
+!passage.jsonl
+!.bind.*

--- a/.behavior/v2026_04_16.fix-keyrack-failure/.route/passage.jsonl
+++ b/.behavior/v2026_04_16.fix-keyrack-failure/.route/passage.jsonl
@@ -1,0 +1,2 @@
+{"stone":"1.vision","status":"blocked","blocker":"review.self","reason":"review.self required: has-questioned-requirements"}
+{"stone":"1.vision","status":"blocked","blocker":"approval","reason":"wait for human approval"}

--- a/.behavior/v2026_04_16.fix-keyrack-failure/0.wish.md
+++ b/.behavior/v2026_04_16.fix-keyrack-failure/0.wish.md
@@ -1,0 +1,21 @@
+# wish
+
+keyrack should findsert a new healthy daemon if the extant one is unhealthy.
+
+currently, `isDaemonReachable` only checks if the socket accepts connections. it does not verify the daemon can process commands. a daemon can accept connections but fail when verifying caller sessions via `ss`.
+
+the system should verify daemon health before reusing it, and spawn a fresh one if unhealthy.
+
+## current failure
+
+```
+$ rhx keyrack unlock --owner ehmpath --env test
+
+UnexpectedCodePathError: daemon UNLOCK command failed
+
+{
+  "error": "UnexpectedCodePathError: no ss output for socket inode\n\n{\n  \"inode\": \"2333397985\"\n}"
+}
+```
+
+the daemon socket existed and accepted the connection, but failed when trying to lookup the socket inode via `ss -xp`.

--- a/.behavior/v2026_04_16.fix-keyrack-failure/1.vision.guard
+++ b/.behavior/v2026_04_16.fix-keyrack-failure/1.vision.guard
@@ -1,0 +1,62 @@
+# guard for vision stone
+#
+# requires human approval before stone can be marked as passed
+# because the self-review prompts require human feedback,
+# the process needs to halt here for human review
+
+judges:
+  - npx rhachet run --repo bhrain --skill route.stone.judge --mechanism approved? --stone $stone --route $route
+
+reviews:
+  self:
+    - slug: has-questioned-requirements
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any requirements that should be questioned?
+
+        for each requirement, ask:
+        - who said this was needed? when? why?
+        - what evidence supports this requirement?
+        - what if we didn't do this — what would happen?
+        - is the scope too large, too small, or misdirected?
+        - could we achieve the goal in a simpler way?
+
+        challenge each requirement and justify why it belongs.
+
+    - slug: has-questioned-assumptions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any hidden assumptions the junior took as requirements?
+
+        for each assumption, ask:
+        - what do we assume here without evidence?
+        - what evidence supports this assumption?
+        - what if the opposite were true?
+        - did the wisher actually say this, or did we infer it?
+        - what exceptions or counterexamples exist?
+
+        surface all hidden assumptions and question each one.
+
+    - slug: has-questioned-questions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any open questions? triage them:
+
+        for each question, ask:
+        - can this be answered via logic now? if so, answer it now.
+        - can this be answered via extant docs or code now? if so, answer it now.
+        - should this be answered via external research later? if so, mark it for research.
+        - does only the wisher know the answer? if so, ask the wisher.
+
+        for each question, ensure it is clearly marked as either:
+        - [answered] — resolved now
+        - [research] — to be answered in the research phase
+        - [wisher] — requires wisher input
+
+        ensure they're enumerated within the vision under "open questions & assumptions"

--- a/.behavior/v2026_04_16.fix-keyrack-failure/1.vision.stone
+++ b/.behavior/v2026_04_16.fix-keyrack-failure/1.vision.stone
@@ -1,0 +1,49 @@
+illustrate the vision implied in the wish .behavior/v2026_04_16.fix-keyrack-failure/0.wish.md
+
+emit into .behavior/v2026_04_16.fix-keyrack-failure/1.vision.yield.md
+
+---
+
+paint a picture of what the world looks like when this wish is fulfilled
+
+testdrive the contract we propose via realworld examples
+
+specifically,
+
+## the outcome world
+
+- what does a day-in-the-life look like with this in place?
+- what's the before/after contrast?
+- what's the "aha" moment where the value clicks?
+
+## user experience
+
+- what usecases do folks fulfill? what goals?
+- what contract inputs & outputs do they leverage?
+- what would it look like to leverage them?
+- what timelines do they go through?
+
+## mental model
+
+- how would users describe this to a friend?
+- what analogies or metaphors fit?
+- what terms would they use vs what terms would we use?
+
+## evaluation
+
+- how well does it solve the goals?
+- what are the pros? the cons?
+- what edgecases exist and how do our contracts keep users in a pit of success?
+
+## open questions & assumptions
+
+- what assumptions have we made?
+- what questions remain unanswered?
+- what must we validate with the wisher before we proceed?
+- what must we research externally?
+
+## what is awkward?
+
+- what feels off or forced?
+- where does the design fight the user's mental model?
+- what tradeoffs feel uncomfortable?

--- a/.behavior/v2026_04_16.fix-keyrack-failure/1.vision.yield.md
+++ b/.behavior/v2026_04_16.fix-keyrack-failure/1.vision.yield.md
@@ -1,0 +1,114 @@
+# vision
+
+fix `getSocketPeerPid` signed vs unsigned integer mismatch.
+
+## wish assumptions invalidated
+
+the wish (`0.wish.md`) proposed:
+> "keyrack should findsert a new healthy daemon if the extant one is unhealthy"
+
+this assumed:
+1. the daemon was "unhealthy"
+2. a fresh daemon spawn would fix it
+3. the solution was health verification + respawn
+
+**all three assumptions are wrong.**
+
+POC investigation (`refs/poc.defect-state.md`, `refs/poc.root-cause-investigation.md`) proved:
+- a fresh daemon spawn **immediately fails with the same error**
+- the daemon is NOT unhealthy — the `ss`-based peer PID lookup code is broken
+- respawn does not fix a code bug
+
+## root cause discovered
+
+**see** `refs/poc.root-cause-investigation.md` for full details.
+
+POC investigation revealed the actual root cause:
+
+**signed vs unsigned integer mismatch** in `getSocketPeerPid.ts`:
+- `/proc/self/fd/$fd` shows socket inode as unsigned (e.g., `2367234854`)
+- `ss -xp` shows socket inode as signed 32-bit (e.g., `-1927732442`)
+- grep for unsigned number never finds signed number
+- affects ~50% of sockets on systems with high socket churn (inodes > 2^31)
+
+a fresh daemon spawn does NOT fix this — the bug is in the peer PID lookup code, not the daemon state.
+
+## the actual fix (implemented)
+
+**option 2 was implemented**: fix the signed/unsigned mismatch in `getSocketPeerPid.ts`.
+
+### the fix
+
+keep `ss`-based approach but grep for both signed and unsigned representations:
+
+```typescript
+// convert unsigned inode to signed 32-bit for ss compatibility
+const inodeNum = parseInt(inode, 10);
+const INT32_MAX = 2147483647; // 2^31 - 1
+const UINT32_MAX = 4294967296; // 2^32
+const signedInode = inodeNum > INT32_MAX ? inodeNum - UINT32_MAX : inodeNum;
+// grep for both representations when inode > INT32_MAX
+const grepPattern = inodeNum > INT32_MAX ? `(${inode}|${signedInode})` : inode;
+```
+
+### before
+
+```
+$ rhx keyrack unlock --owner ehmpath --env test
+
+UnexpectedCodePathError: daemon UNLOCK command failed
+{
+  "error": "UnexpectedCodePathError: no ss output for socket inode\n\n{\n  \"inode\": \"2367234854\"\n}"
+}
+```
+
+user sees cryptic error about `ss` unable to locate socket inode. the daemon is healthy, but the peer PID lookup fails because `ss -xp` shows the inode as `-1927732442` (signed) while we grep for `2367234854` (unsigned).
+
+### after
+
+```
+$ rhx keyrack unlock --owner ehmpath --env test
+
+🔓 keyrack unlock
+   └─ ehmpathy.test.API_KEY
+      ├─ env: test
+      ├─ org: ehmpathy
+      ├─ vault: os.secure
+      └─ expires in: 60m
+```
+
+the fix greps for both `2367234854` and `-1927732442`, locates the socket regardless of how `ss` represents the inode.
+
+### test coverage
+
+1. **unit tests** (`getSocketPeerPid.test.ts`) — prove the signed/unsigned conversion math:
+   - inode below INT32_MAX → same value
+   - inode above INT32_MAX → negative signed representation
+   - grep pattern includes both representations when needed
+
+2. **acceptance tests** (`keyrack.status.env-filter.acceptance.test.ts`) — prove CLI behavior:
+   - invalid `--env` fails with helpful error
+   - valid `--env` works in isolated test environment
+
+## alternative considered
+
+### option 1: SO_PEERCRED via native addon
+
+SO_PEERCRED is the correct unix mechanism for peer credential lookup. node.js doesn't expose it directly, but can be accessed via:
+- `ffi-napi` to call `getsockopt(fd, SOL_SOCKET, SO_PEERCRED, ...)`
+- native C++ addon
+- published npm package like `unix-socket-credentials`
+
+**why not chosen**: adds native dependency, increases complexity. the signed/unsigned fix is simpler and solves the immediate problem. SO_PEERCRED remains a good future improvement.
+
+---
+
+## appendix: original vision (superseded by root cause discovery)
+
+the content below was written before root cause was discovered. it proposed daemon health checks and respawn logic. this approach was **invalidated** when POC proved:
+
+1. the daemon is healthy — the bug is in the peer PID lookup code
+2. daemon respawn fails with the same error (code bug, not state)
+3. the fix is to correct the signed/unsigned mismatch, not to add health checks
+
+the superseded content is preserved in git history for reference.

--- a/.behavior/v2026_04_16.fix-keyrack-failure/5.1.execution.from_vision.guard
+++ b/.behavior/v2026_04_16.fix-keyrack-failure/5.1.execution.from_vision.guard
@@ -1,0 +1,159 @@
+# guard for execution stone (from vision - nano size)
+# includes standardized self-review frame
+
+artifacts:
+  # track execution progress
+  - "$route/5.1.execution.from_vision.yield.md"
+  # track actual implementation in src/
+  - "src/**/*"
+
+reviews:
+  self:
+    # 1. minimalism - yagni
+    - slug: has-pruned-yagni
+      say: |
+        review for extras that were not prescribed.
+
+        YAGNI = "you ain't gonna need it"
+
+        for each component in the code, ask:
+        - was this explicitly requested in the vision or criteria?
+        - is this the minimum viable way to satisfy the requirement?
+        - did we add abstraction "for future flexibility"?
+        - did we add features "while we're here"?
+        - did we optimize before we knew it was needed?
+
+        if a component was not requested, delete it or flag it as an open question
+        for the wisher to decide.
+
+    # 2. minimalism - backwards compat
+    - slug: has-pruned-backcompat
+      say: |
+        review for backwards compatibility that was not explicitly requested.
+
+        for each backwards-compat concern in the code, ask:
+        - did the wisher explicitly say to maintain this compatibility?
+        - is there evidence this backwards compat is needed?
+        - or did we assume it "to be safe"?
+
+        if backwards compat was not explicitly requested:
+        1. flag it as an open question for the wisher
+        2. eliminate it if not confirmed as required
+        3. make the open question very clearly reported
+
+    # 3. consistency - mechanisms
+    - slug: has-consistent-mechanisms
+      say: |
+        review for new mechanisms that duplicate extant functionality.
+
+        unless the ask was to refactor, be consistent with extant mechanisms.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). look for extant utilities and patterns.
+
+        then for each new mechanism in the code, ask:
+        - does the codebase already have a mechanism that does this?
+        - do we duplicate extant utilities or patterns?
+        - could we reuse an extant component instead of a new one?
+
+        if a new mechanism duplicates extant functionality:
+        1. replace with the extant mechanism
+        2. or flag as an open question if unsure
+
+    # 4. consistency - conventions
+    - slug: has-consistent-conventions
+      say: |
+        review for divergence from extant names and patterns.
+
+        unless the ask was to refactor, be consistent with extant conventions.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). identify extant name conventions and patterns.
+
+        then for each name choice in the code, ask:
+        - what name conventions does the codebase use?
+        - do we use a different namespace, prefix, or suffix pattern?
+        - do we introduce new terms when extant terms exist?
+        - does our structure match extant patterns?
+
+        if we diverge from extant conventions:
+        1. align with the extant convention
+        2. or flag as an open question if the extant convention seems wrong
+
+    # 5. review against behavior declaration - coverage
+    - slug: behavior-declaration-coverage
+      say: |
+        review for coverage of the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have omitted
+        requirements or left features unimplemented.
+
+        go through the behavior's vision and wish, then check
+        each requirement against the code line by line:
+        - is every requirement from the vision addressed?
+        - did the junior skip or forget any part of the spec?
+
+        fix all gaps before you continue.
+
+    # 6. review against behavior declaration - adherance
+    - slug: behavior-declaration-adherance
+      say: |
+        review for adherance to the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have drifted
+        from the spec or implemented items incorrectly.
+
+        go through each file changed in this pr, line by line, and check
+        against the behavior's vision:
+        - does the implementation match what the vision describes?
+        - did the junior misinterpret or deviate from the spec?
+
+        fix all gaps before you continue.
+
+    # 7. review against role standards - adherance
+    - slug: role-standards-adherance
+      say: |
+        review for adherance to mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have introduced
+        bad practices or violated patterns that we require.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this code
+        - confirm you have not missed any rule categories
+
+        then go through each file changed in this pr, line by line, and check:
+        - does the code follow mechanic standards correctly?
+        - are there violations of required patterns?
+        - did the junior introduce anti-patterns, bad practices, or deviations from our conventions?
+
+        fix all gaps before you continue.
+
+    # 8. review against role standards - coverage
+    - slug: role-standards-coverage
+      say: |
+        review for coverage of mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have forgotten
+        best practices or omitted patterns that should be present.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this code
+        - confirm you have not missed any rule categories
+
+        then go through each file changed in this pr, line by line, and check:
+        - are all relevant mechanic standards applied?
+        - are there patterns that should be present but are absent?
+        - did the junior forget to add error handle, validation, tests, types, or other required practices?
+
+        fix all gaps before you continue.
+
+  peer:
+    - npx rhachet run --repo bhrain --skill review --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with 'src/**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.failhides.md' --mode hard
+
+judges:
+  - npx rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 3

--- a/.behavior/v2026_04_16.fix-keyrack-failure/5.1.execution.from_vision.stone
+++ b/.behavior/v2026_04_16.fix-keyrack-failure/5.1.execution.from_vision.stone
@@ -1,0 +1,15 @@
+bootup your mechanic's role via `npx rhachet roles boot --repo ehmpathy --role mechanic`
+
+then, execute the vision directly
+- .behavior/v2026_04_16.fix-keyrack-failure/1.vision.md
+
+ref:
+- .behavior/v2026_04_16.fix-keyrack-failure/0.wish.md
+
+
+---
+
+track your progress
+
+emit todos and check them off into
+- .behavior/v2026_04_16.fix-keyrack-failure/5.1.execution.from_vision.yield.md

--- a/.behavior/v2026_04_16.fix-keyrack-failure/5.3.verification.guard
+++ b/.behavior/v2026_04_16.fix-keyrack-failure/5.3.verification.guard
@@ -1,0 +1,238 @@
+artifacts:
+  # track verification progress
+  - "$route/5.3.verification.yield.md"
+  # track actual implementation in src/
+  - "src/**/*"
+
+reviews:
+  self:
+    - slug: has-behavior-coverage
+      say: |
+        double-check: does the verification checklist show every behavior from wish/vision has a test?
+
+        - is every behavior in 0.wish.md covered?
+        - is every behavior in 1.vision.md covered?
+        - can you point to each test file in the checklist?
+
+        **if any behavior lacks a test, write the test NOW.** do not pass this gate with gaps.
+
+    - slug: has-zero-test-skips
+      say: |
+        double-check: did you verify zero skips — and REMOVE any you found?
+
+        - no .skip() or .only() found?
+        - no silent credential bypasses?
+        - no prior failures carried forward?
+
+        **if you found skips, did you remove them and make those tests pass?**
+
+        this is buttonup. skips are gaps. gaps get fixed, not noted.
+
+    - slug: has-all-tests-passed
+      say: |
+        double-check: did all tests pass? prove it.
+
+        **zero unproven claims.** you must cite the exact command and output.
+
+        for each test suite:
+        - what command did you run?
+        - what was the exit code?
+        - how many tests passed?
+
+        example proof:
+        ```
+        $ npm run test:unit
+        > exit 0
+        > 47 tests passed
+        ```
+
+        if you cannot cite the command and output, you did not prove it.
+
+        zero tolerance for extant failures:
+        - "it was already broken" is not an excuse — fix it
+        - "it's unrelated to my changes" is not an excuse — fix it
+        - flaky tests must be stabilized, not tolerated
+        - every failure is your responsibility now
+
+        zero tolerance for fake tests:
+        - tests that always pass are fraud
+        - tests that mock the system under test prove nothingness
+        - tests must verify real behavior
+
+        zero tolerance for credential excuses:
+        - "i don't have creds" means get them or mock them
+        - silent bypasses are forbidden
+        - if creds block tests, that is a BLOCKER — not a deferral
+
+    - slug: has-preserved-test-intentions
+      say: |
+        double-check: did you preserve test intentions?
+
+        for every test you touched:
+        - what did this test verify before?
+        - does it still verify the same behavior after?
+        - did you change what the test asserts, or fix why it failed?
+
+        forbidden:
+        - weaken assertions to make tests pass
+        - remove test cases that "no longer apply"
+        - change expected values to match broken output
+        - delete tests that fail instead of fix code
+
+        the test knew a truth. if it failed, either:
+        - the code is wrong — fix the code
+        - the test has a bug — fix the bug, keep the intention
+        - requirements changed — document why, get approval
+
+        to "fix tests" via changed intent is not a fix — it is at worst
+        malicious deception, at best reckless negligence. unacceptable.
+
+    - slug: has-journey-tests-from-repros
+      say: |
+        double-check: did you implement each journey sketched in repros?
+
+        look back at the repros artifact:
+        - .behavior/v2026_04_16.fix-keyrack-failure/3.2.distill.repros.experience.*.md
+
+        for each journey test sketch in repros:
+        - is there a test file for it?
+        - does the test follow the BDD given/when/then structure?
+        - does each `when([tN])` step exist?
+
+        **if any journey was planned but not implemented, go back and add it NOW.**
+
+        this is buttonup. absent journey tests = incomplete implementation.
+        test coverage proves prod coverage. no test = no proof = not done.
+
+    - slug: has-contract-output-variants-snapped
+      say: |
+        double-check: does each public contract have EXHAUSTIVE snapshots?
+
+        **zero gaps in caller experience.** every contract must snap every output variant.
+
+        for each new or modified public contract:
+
+        | contract type | what to snap | required variants |
+        |---------------|--------------|-------------------|
+        | cli command | stdout + stderr | success, error, --help, edge cases |
+        | api endpoint | response body | 2xx, 4xx, 5xx, edge cases |
+        | sdk method | return value | success, error, edge cases |
+
+        checklist per contract:
+        - [ ] positive path (success) is snapped
+        - [ ] negative path (error) is snapped
+        - [ ] help/usage is snapped (for cli)
+        - [ ] edge cases are snapped (empty, invalid, boundary)
+        - [ ] snapshot shows actual output, not placeholder
+
+        why this matters:
+        - snapshots enable vibecheck in prs — reviewers see actual output without execute
+        - snapshots detect drift over time — output changes surface in diffs
+        - absent variants mean blind spots in review
+        - exhaustive coverage proves the contract works for all callers
+
+        **zero leniency.** if a contract lacks any variant, add the test case NOW.
+
+        if you find yourself about to say "this variant isn't worth a snapshot" — stop.
+        that is the variant that will break in prod. snap it.
+
+        this is buttonup. absent snapshots = absent proof. add them or fail this gate.
+
+    - slug: has-snap-changes-rationalized
+      say: |
+        double-check: is every `.snap` file change intentional and justified?
+
+        for each `.snap` file in git diff:
+        1. what changed? (added, modified, deleted)
+        2. was this change intended or accidental?
+        3. if intended: what is the rationale?
+        4. if accidental: revert it or explain why the new output is an improvement
+
+        common regressions caught here:
+        - output format degraded (lost alignment, lost structure)
+        - error messages became less helpful
+        - timestamps or ids leaked into snapshots (flaky)
+        - extra output added unintentionally
+
+        forbidden:
+        - "updated snapshots" without per-file rationale
+        - bulk snapshot updates without review
+        - regressions accepted without justification
+
+        every snap change tells a story. make sure the story is intentional.
+
+    - slug: has-critical-paths-frictionless
+      say: |
+        double-check: are the critical paths frictionless in practice?
+
+        look back at the repros artifact for critical paths:
+        - .behavior/v2026_04_16.fix-keyrack-failure/3.2.distill.repros.experience.*.md
+
+        for each critical path:
+        - run through it manually — is it smooth?
+        - are there unexpected errors?
+        - does it feel effortless to the user?
+
+        critical paths must "just work." if there's friction, fix it now.
+
+    - slug: has-ergonomics-validated
+      say: |
+        double-check: does the actual input/output match what felt right at repros?
+
+        compare the implemented input/output to what was sketched in repros:
+        - does the actual input match the planned input?
+        - does the actual output match the planned output?
+        - did the design change between repros and implementation?
+
+        if the ergonomics drifted, either:
+        - update repros to reflect the better design, or
+        - fix the implementation to match the planned ergonomics
+
+    - slug: has-play-test-convention
+      say: |
+        double-check: are journey test files named correctly?
+
+        journey tests should use `.play.test.ts` suffix:
+        - `feature.play.test.ts` — journey test
+        - `feature.play.integration.test.ts` — if repo requires integration runner
+        - `feature.play.acceptance.test.ts` — if repo requires acceptance runner
+
+        verify:
+        - are journey tests in the right location?
+        - do they have the `.play.` suffix?
+        - if not supported, is the fallback convention used?
+
+    - slug: has-fixed-all-gaps
+      say: |
+        final buttonup check: did you FIX every gap you found, or just detect it?
+
+        **this is the buttonup phase. detection is not enough — you must fix.**
+
+        look back at all the reviews above. for every gap you identified:
+        - absent test coverage → did you WRITE the test?
+        - absent prod coverage → did you IMPLEMENT the behavior?
+        - failed test → did you FIX the code or test?
+        - skipped test → did you REMOVE the skip and make it pass?
+
+        **zero omissions.** if any review above surfaced a gap, that gap must be fixed before you pass this gate.
+
+        ask yourself:
+        - did i just note the gap, or did i actually fix it?
+        - is there any item marked "todo" or "later"? (forbidden)
+        - is there any coverage marked incomplete? (forbidden)
+
+        **if you detected it, you fixed it.** prove it with citations.
+
+        this is the final self-review. you are about to hand off to peer review.
+        prove that all items above were addressed — not deferred.
+
+  peer:
+    # verify contract snapshot exhaustiveness
+    - npx rhachet run --repo bhrain --skill review --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --diffs since-main --paths-with '{src,blackbox}/**/*.{test,snap}.ts' --join intersect --output '$route/.reviews/$stone.peer-review.contract-snapshots.md' --mode hard
+
+    # verify external contract integration tests
+    - npx rhachet run --repo bhrain --skill review --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.external-contract-integration-tests.md' --diffs since-main --paths-with '{src,blackbox}/**/*.{test,integration}.ts' --join intersect --output '$route/.reviews/$stone.peer-review.external-contracts.md' --mode hard
+
+judges:
+  # enforce peer reviews pass with zero blockers
+  - npx rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 0

--- a/.behavior/v2026_04_16.fix-keyrack-failure/5.3.verification.stone
+++ b/.behavior/v2026_04_16.fix-keyrack-failure/5.3.verification.stone
@@ -1,0 +1,304 @@
+prove the deliverable works via test verification — fix all gaps
+
+---
+
+## .what
+
+this is the verification gate — the **buttonup phase**.
+
+you cannot pass execution without proof that all tests pass. more importantly: **test coverage enforces prod coverage**. if tests are absent, prod is incomplete. if prod is incomplete, fix it.
+
+## .the buttonup mandate: zero omissions
+
+**this is not a detection phase. this is a completion phase.**
+
+when you find a gap, you do not note it and move on. you **fix it**.
+
+| gap type | action |
+|----------|--------|
+| absent test coverage | write the test NOW |
+| absent prod coverage | implement the behavior NOW |
+| failed test | fix the code or fix the test NOW |
+| skipped test | remove the skip and make it pass NOW |
+
+**if you detect it, you fix it. no exceptions.**
+
+## .strictness: zero tolerance, zero exceptions
+
+**this gate enforces absolute standards. there is no leniency.**
+
+| constraint | definition |
+|------------|------------|
+| zero deferrals | you cannot defer any test to later. all tests pass now or you fail. |
+| zero fake tests | tests must verify real behavior. assertions that always pass are fraud. |
+| zero unproven claims | every claim of "test passes" must cite the exact command run and output. |
+| zero credential excuses | "i don't have creds" is not an excuse. get them, mock them, or fail. |
+| zero skips | .skip() and .only() are forbidden. silent bypasses are forbidden. |
+| zero exceptions | there are no special cases. the rules apply to all. |
+| zero omissions | if you find a gap in coverage, you fix it — test or prod. |
+
+**if a blocker prevents tests from run, that is a BLOCKER. full stop.**
+
+you do not proceed. you do not defer. you fix it or you fail the gate.
+
+## .why
+
+**why does this gate exist?**
+
+your crew is about to review a pr you wrote. they need proof it works — not words, proof. tests are that proof.
+
+**test coverage drives prod coverage.** if a behavior lacks a test, that behavior is unproven. unproven behaviors are incomplete deliverables. the test proves the implementation exists and works.
+
+without this gate:
+- tests might fail and nobody notices
+- tests might be skipped and nobody notices
+- behaviors might lack coverage and nobody notices
+- broken code ships to peers
+- incomplete implementations slip through
+
+with this gate:
+- every test passes or you fix it
+- every behavior has coverage or you add it
+- every skip is removed or justified
+- proven code ships to peers
+- **gaps get fixed, not deferred**
+
+**the cardinal rules**:
+1. never leave behavior without true, dependable test coverage
+2. never offload work onto your crew unless there is truly, fundamentally no other option
+3. never claim a test passes without cite of the exact command and output
+
+you fix it yourself. you exhaust every option: debug, research, try alternatives. only when you hit a wall that is physically impossible to climb alone — credentials only the foreman possesses, access only they can grant — only then may you ask for help.
+
+## .how
+
+reference the below for full context
+- .behavior/v2026_04_16.fix-keyrack-failure/0.wish.md
+- .behavior/v2026_04_16.fix-keyrack-failure/1.vision.md
+- .behavior/v2026_04_16.fix-keyrack-failure/2.1.criteria.blackbox.md (if declared)
+- .behavior/v2026_04_16.fix-keyrack-failure/3.2.distill.repros.experience.*.md (if declared) ← **repros artifact**
+
+---
+
+### step 1: emit verification checklist
+
+emit to
+- .behavior/v2026_04_16.fix-keyrack-failure/5.3.verification.yield.md
+
+this is your roadmap. emit it first, then work through it step by step.
+
+**checklist structure:**
+
+```
+## verification checklist
+
+### behavior coverage (with reference to repros)
+
+for each journey sketched in repros, verify it was implemented with snapshots.
+
+| journey (from repros) | test file | snapshots? | critical path? | ergonomics ok? | status |
+|-----------------------|-----------|------------|----------------|----------------|--------|
+| {journey 1}           | {path}    | ✓ / ✗      | ✓ frictionless / needs work | ✓ natural / needs work | ⏳ |
+| {journey 2}           | {path}    | ✓ / ✗      | ✓ frictionless / needs work | ✓ natural / needs work | ⏳ |
+...
+
+### zero skips verified
+- [ ] no .skip() or .only() found
+- [ ] no silent credential bypasses
+- [ ] no prior failures carried forward
+
+### snapshot coverage for contract outputs
+
+each public contract needs dedicated snapshots that demonstrate its stdout for:
+- **vibechecks in prs** — reviewers see actual output without executing code
+- **drift detection** — changes to output surface in diffs over time
+
+| contract | output variants | snapshot file | status |
+|----------|-----------------|---------------|--------|
+| {command 1} | success, error, help | {path.snap} | ⏳ |
+| {command 2} | success, error, help | {path.snap} | ⏳ |
+...
+
+checklist:
+- [ ] every new cli command has `.snap` snapshots for stdout/stderr
+- [ ] every new app screen has `.snap` snapshots for screenshots
+- [ ] every new sdk method has `.snap` snapshots for responses
+- [ ] each output variant is exercised (success, error, edge cases)
+- [ ] snapshots demonstrate actual output, not just "it ran"
+
+### snapshot change rationalization
+
+for each `.snap` file changed, rationalize whether the change was intended or accidental:
+
+| snap file | change type | intended? | rationale |
+|-----------|-------------|-----------|-----------|
+| {path.snap} | added / modified / deleted | yes / no | {why this change is correct} |
+...
+
+checklist:
+- [ ] every `.snap` change has been reviewed
+- [ ] intended changes have clear rationale
+- [ ] accidental changes have been reverted or justified as improvements
+
+### tests executed — with proof
+
+**every test run must be proven with exact command and output.**
+
+| test suite | command run | result | proof (exit code + summary) |
+|------------|-------------|--------|----------------------------|
+| types | `npm run test:types` | ✓ / ✗ | exit 0, no errors |
+| lint | `npm run test:lint` | ✓ / ✗ | exit 0, no errors |
+| format | `npm run test:format` | ✓ / ✗ | exit 0, no errors |
+| unit | `npm run test:unit` | ✓ / ✗ | exit 0, N tests passed |
+| integration | `npm run test:integration` | ✓ / ✗ | exit 0, N tests passed |
+| acceptance | `npm run test:acceptance` | ✓ / ✗ | exit 0, N tests passed |
+
+checklist:
+- [ ] every test command was run (not "i think it passed")
+- [ ] every test command output was observed (not assumed)
+- [ ] the exact exit code was verified (0 = pass, non-zero = fail)
+- [ ] no tests were skipped, mocked, or faked
+
+**zero unproven claims.** if you claim a test passes, cite the command and output.
+
+### contract output snapshot exhaustiveness
+
+**every user-faced contract must have exhaustive snapshot coverage.**
+
+| contract type | contract | positive path snapped? | negative path snapped? | edge cases snapped? |
+|---------------|----------|------------------------|------------------------|---------------------|
+| cli | {command} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+| api | {endpoint} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+| sdk | {method} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+
+checklist:
+- [ ] every cli command has stdout/stderr snapshots for success, error, and help
+- [ ] every api endpoint has response snapshots for success and error codes
+- [ ] every sdk method has return value snapshots for success and error
+- [ ] every contract has edge case snapshots (empty input, invalid input, boundary)
+
+**zero gaps in caller experience.** the reviewer must see exactly what callers see.
+
+### blockers
+- none (or list handoff references)
+```
+
+update the checklist as you complete each step below.
+
+---
+
+### step 2: verify AND FIX behavior coverage
+
+walk through wish and vision:
+- every behavior promised must have an acceptance test
+- for each behavior, you can point to the test file
+- no behavior left untested
+
+**why?** your crew trusts the test suite. if a behavior isn't tested, it isn't proven. untested behaviors are unverified promises.
+
+**test coverage enforces prod coverage.** if a test is absent, either:
+1. the behavior was not implemented → IMPLEMENT IT NOW
+2. the behavior was implemented without a test → WRITE THE TEST NOW
+
+if a behavior lacks a test, **write one NOW**. do not move on with gaps. update your checklist when done.
+
+---
+
+### step 3: verify AND FIX zero skips
+
+scan for forbidden patterns:
+- `.skip()` or `.only()` in test files
+- `if (!credentials) return` or similar silent bypasses
+- prior failures carried forward (known-broken tests)
+
+**why?** failures are better than skips. skips hide problems. failures expose them. a skipped test is a lie — it pretends coverage exists when it doesn't.
+
+**this is buttonup.** if you find skips:
+1. REMOVE the skip
+2. MAKE the test pass (fix the code or fix the test)
+3. update your checklist
+
+do not note skips and move on. fix them. all tests must run.
+
+---
+
+### step 4: run all tests AND FIX all failures
+
+run each test suite and **cite the exact command and output**.
+
+```bash
+npm run test:types      # cite exit code
+npm run test:lint       # cite exit code
+npm run test:format     # cite exit code
+npm run test:unit       # cite exit code + test count
+npm run test:integration # cite exit code + test count
+npm run test:acceptance  # cite exit code + test count
+```
+
+all must pass — no exceptions. no deferrals. no "i'll fix it later."
+
+**this is buttonup.** if tests fail, fix them. that is the job.
+
+failures indicate one of:
+1. prod code is broken → FIX THE PROD CODE
+2. test has a bug → FIX THE TEST BUG (preserve intention)
+3. coverage gap exists → FILL THE GAP
+
+**consider all failures as defects from this pr.** there are no "prior failures."
+
+if a test was broken before you started — fix it. if a test is flaky — fix it. if a test fails for reasons unrelated to your changes — fix it anyway. you do not get to say "that was already broken." you are here now. you fix it.
+
+**take initiative. take ownership.**
+
+**preserve test intentions.** when you fix a test, you fix why it failed — not what it tests. to change what a test verifies is not a fix. it is at worst malicious deception, at best reckless negligence. the test knew a truth. if it fails, either the code is wrong or the test has a bug. fix the cause, not the assertion.
+
+**zero fake tests.** a test that always passes is fraud. a test that skips is a lie. a test that mocks the system under test proves nothingness. tests must verify real behavior against real code.
+
+**escalation path:**
+1. debug the failure — read the error, understand the cause
+2. research — search for similar issues, read docs
+3. try alternatives — different approach, different tool
+4. ask for help — other resources, other clones
+5. deeper research — exhaust every option
+6. only if insurmountable — emit handoff (see step 5)
+
+**ask yourself at each level:**
+- did i read the error message carefully?
+- did i search for similar issues?
+- did i try a different approach?
+- did i isolate the problem?
+- did i ask for help?
+- did i exhaust every option?
+
+you move to handoff only when you can answer "yes" to all of the above and still cannot proceed.
+
+update your checklist when all tests pass.
+
+---
+
+### step 5: handoff (only if insurmountable)
+
+a handoff is a document that transfers work to your foreman because you hit a wall that is physically impossible to climb alone.
+
+**foreman-only blockers:**
+- credentials only the foreman possesses
+- external access only the foreman can grant
+- approval that requires foreman authority
+
+handoff is the absolute last resort. you must exhaust every option before you consider it.
+
+if you need to emit a handoff:
+
+emit to
+- .behavior/v2026_04_16.fix-keyrack-failure/5.3.verification.handoff.v$N.to_foreman.md
+
+**handoff must include:**
+1. what you tried (list every approach you attempted)
+2. why each approach failed (be specific)
+3. what makes this fundamentally impossible without foreman intervention
+4. is this truly a "foreman possesses the key" situation?
+5. rewind instruction: `rhx route.stone.set --stone 5.3.verification --as rewound`
+
+your crew should read your handoff and think: "yes, there was truly no other way."
+
+update your checklist to reference the handoff.

--- a/.behavior/v2026_04_16.fix-keyrack-failure/refs/poc.defect-state.md
+++ b/.behavior/v2026_04_16.fix-keyrack-failure/refs/poc.defect-state.md
@@ -1,0 +1,140 @@
+# proof of concept: defect state
+
+## findings
+
+timestamp: observed on 2026-04-16 POC
+
+### discovery trace
+
+how we found the daemon process:
+
+1. read `getKeyrackDaemonSocketPath.ts` — socket path format is `$XDG_RUNTIME_DIR/keyrack.$SESSION.$HOMEHASH.$owner.sock`
+
+2. read `getHomeHash.ts` — home hash is truncated sha256 of `$HOME`
+
+3. computed home hash:
+```bash
+printf '/home/vlad' | sha256sum | head -c 8
+# → 83db27ef
+```
+
+4. found PID file:
+```bash
+# searched /run/user/1000 for keyrack.*.83db27ef.*
+# → /run/user/1000/keyrack.4.83db27ef.ehmpath.pid
+```
+
+5. read PID:
+```bash
+cat /run/user/1000/keyrack.4.83db27ef.ehmpath.pid
+# → 3919920
+```
+
+6. verified process alive:
+```bash
+cat /proc/3919920/cmdline
+# → node ... startKeyrackDaemon({ socketPath: "...ehmpath.sock" })
+```
+
+7. verified socket exists:
+```bash
+file /run/user/1000/keyrack.4.83db27ef.ehmpath.sock
+# → socket
+```
+
+### daemon state
+
+| artifact | path | value |
+|----------|------|-------|
+| PID file | /run/user/1000/keyrack.4.83db27ef.ehmpath.pid | 3919920 |
+| socket file | /run/user/1000/keyrack.4.83db27ef.ehmpath.sock | exists (type: socket) |
+| process | /proc/3919920/cmdline | alive, runs keyrack daemon |
+
+### failure
+
+```
+$ rhx keyrack status --owner ehmpath
+
+UnexpectedCodePathError: daemon STATUS command failed
+{
+  "error": "UnexpectedCodePathError: no ss output for socket inode\n\n{\n  \"inode\": \"2367234854\"\n}"
+}
+```
+
+### analysis
+
+1. daemon process alive (PID 3919920)
+2. socket file exists
+3. client connects to socket successfully
+4. daemon receives command
+5. daemon calls `ss -xp` to verify caller session
+6. `ss` returns no output for the socket inode
+7. daemon throws `UnexpectedCodePathError`
+
+the daemon cannot process ANY commands in this state.
+`keyrack daemon prune` also fails with the same error.
+
+## proof of solution
+
+### steps executed
+
+```bash
+# step 1: kill daemon process
+kill 3919920
+# daemon exited and cleaned up socket + PID files on exit
+
+# step 2: verify daemon gone
+rhx keyrack status --owner ehmpath
+# → daemon: not found
+
+# step 3: unlock spawns fresh daemon
+rhx keyrack unlock --owner ehmpath --env test
+# → [keyrack-daemon] spawned background daemon (pid: 687954)
+# → 🔓 keyrack unlock
+```
+
+### result
+
+**solution validated.** kill via SIGTERM → fresh daemon spawn → command succeeds.
+
+### note
+
+the daemon cleaned up its own socket + PID files on SIGTERM exit. the recovery flow can rely on:
+1. send SIGTERM to PID from PID file
+2. daemon cleans up on exit (or files already gone if process dead)
+3. spawn fresh daemon
+4. retry command
+
+## critical discovery: systemic issue
+
+fresh daemon (PID 687954) **immediately** fails with same error:
+
+```
+UnexpectedCodePathError: no ss output for socket inode
+{ "inode": "2370788919" }
+```
+
+this is NOT daemon staleness. `ss -xp` is consistently broken on this machine. the fix we're implementing will NOT help — the fresh daemon has the same problem.
+
+### root cause hypothesis
+
+the `ss -xp` command requires elevated privileges or specific kernel config to return peer process info. on this machine, it returns no output for any socket inode.
+
+### implication for fix
+
+the reactive recovery (kill → respawn → retry) will NOT work if `ss` is systemically broken. the retry will fail too.
+
+need to investigate:
+1. why `ss -xp` returns no output
+2. whether this is a permission issue
+3. whether there's an alternative to `ss` for peer PID lookup
+
+---
+
+## root cause identified
+
+see `poc.root-cause-investigation.md` for details.
+
+**summary**: signed vs unsigned integer mismatch between `/proc/self/fd` (unsigned) and `ss -xp` (signed 32-bit). when socket inode > 2^31, they don't match on grep.
+
+**implication**: the vision needs to change from "reactive daemon restart" to "fix the peer PID lookup mechanism". the daemon itself is not unhealthy — the `ss`-based peer lookup is fundamentally broken for high inodes.

--- a/.behavior/v2026_04_16.fix-keyrack-failure/refs/poc.root-cause-investigation.md
+++ b/.behavior/v2026_04_16.fix-keyrack-failure/refs/poc.root-cause-investigation.md
@@ -1,0 +1,153 @@
+# root cause investigation
+
+## the code path
+
+`getSocketPeerPid.ts` does:
+
+```
+1. socket._handle.fd → file descriptor number
+2. readlink /proc/self/fd/$fd → "socket:[INODE]"
+3. ss -xp | grep INODE → find line with process info
+4. parse pid=NNNN from output
+```
+
+## the failure
+
+step 3 returns empty: `ss -xp | grep $inode` finds no match.
+
+## hypothesis
+
+`ss -xp` shows unix sockets with process ownership. but:
+
+- the inode from `/proc/self/fd/$fd` is the daemon's endpoint of the connection
+- `ss` may not list this inode, or may list it without process info
+- `-p` flag may require CAP_NET_ADMIN to see other processes' sockets
+
+## questions to answer
+
+1. what does `ss -xp` actually output on this machine?
+2. does the inode from the accepted connection appear in `ss` output?
+3. is this a permission issue (needs root or CAP_NET_ADMIN)?
+4. is there an alternative way to get peer PID (SO_PEERCRED)?
+
+## alternative: SO_PEERCRED
+
+the code comment says "node.js does not expose SO_PEERCRED directly". but:
+
+- SO_PEERCRED is the correct way to get peer credentials on unix sockets
+- could use a native addon or FFI to call getsockopt(SO_PEERCRED)
+- this would be more reliable than parse of `ss` output
+
+## next step
+
+need to manually inspect `ss -xp` output to understand what it shows.
+
+---
+
+## ROOT CAUSE FOUND
+
+### the bug: signed vs unsigned integer mismatch
+
+the socket inode from `/proc/self/fd/$fd` is shown as **unsigned** (always positive).
+
+`ss -xp` displays socket identifiers as **signed 32-bit integers** (can be negative when inode > 2^31).
+
+when the inode is > 2147483647 (2^31), the representations differ:
+
+| source | inode representation |
+|--------|---------------------|
+| `/proc/self/fd/$fd` | `socket:[2365553034]` (unsigned) |
+| `ss -xp` output | `-1929414262` (signed) |
+
+the grep for the unsigned number will never find the signed number.
+
+### proof
+
+from `ss -xp` output:
+
+```
+u_str ESTAB 0 0 * -1929414262 * -1929414261 users:(("firefox-bin",pid=58996,fd=258))
+```
+
+the `-1929414262` is a signed 32-bit representation. as unsigned: `4294967296 + (-1929414262) = 2365553034`.
+
+the daemon's error showed inode `2367234854`. as signed 32-bit: `2367234854 - 4294967296 = -1927732442`.
+
+the grep searches for `2367234854` but ss shows `-1927732442`. no match.
+
+### why this is systemic
+
+this is NOT a stale daemon issue. the signed/unsigned mismatch affects ANY socket with inode > 2^31 (about 50% of all sockets on a long-running system with high socket churn).
+
+the longer the system runs, the higher the socket inode counter grows, the more likely this bug manifests.
+
+### fix options
+
+1. **convert to signed before grep**: compute `inode > 2^31 ? inode - 2^32 : inode` and grep for both
+2. **use SO_PEERCRED**: node.js doesn't expose it directly, but a native addon or FFI could call `getsockopt(fd, SOL_SOCKET, SO_PEERCRED, &cred, &len)`
+3. **use lsof instead of ss**: `lsof -p $pid` with the daemon's own PID to find connected sockets
+
+option 2 (SO_PEERCRED) is the correct fix — it's what unix socket peer credential lookup is designed for. the `ss` approach was a workaround for node.js not exposing SO_PEERCRED.
+
+---
+
+## FIX PROVEN
+
+### the patch
+
+option 1 (convert to signed before grep) was implemented in `getSocketPeerPid.ts`:
+
+```typescript
+const inodeNum = parseInt(inode, 10);
+const INT32_MAX = 2147483647; // 2^31 - 1
+const UINT32_MAX = 4294967296; // 2^32
+const signedInode =
+  inodeNum > INT32_MAX ? inodeNum - UINT32_MAX : inodeNum;
+const grepPattern =
+  inodeNum > INT32_MAX ? `(${inode}|${signedInode})` : inode;
+
+let ssOutput: string;
+try {
+  ssOutput = execSync(`ss -xp | grep -E "${grepPattern}" || true`, {
+    encoding: 'utf-8',
+    timeout: 5000,
+  });
+}
+```
+
+the patch greps for both the unsigned and signed representations when the inode exceeds 2^31.
+
+### test steps
+
+1. patch `src/.../getSocketPeerPid.ts`
+2. rebuild: `npm run build`
+3. prune extant daemon: `npx rhachet keyrack daemon prune --owner ehmpath`
+4. test unlock: `npx rhachet keyrack unlock --owner ehmpath --env test`
+5. test status: `npx rhachet keyrack status --owner ehmpath`
+
+### result
+
+```
+$ npx rhachet keyrack unlock --owner ehmpath --env test
+[keyrack-daemon] spawned background daemon (pid: 2684369)
+🔓 keyrack unlock
+
+$ npx rhachet keyrack status --owner ehmpath
+🔐 keyrack status
+   ├─ owner: ehmpath
+   ├─ recipients:
+   │  └─ default (age)
+   └─ daemon: active ✨
+      └─ (no keys unlocked)
+```
+
+**fix validated.** both unlock and status succeed after the patch.
+
+### key insight
+
+the daemon runs compiled code from `dist/`, not TypeScript from `src/`. a patch to source requires:
+1. `npm run build` to compile
+2. daemon prune to kill extant daemon
+3. next command spawns fresh daemon with new code
+
+see `howto.diagnose-daemon-errors.md` for the full diagnosis workflow.

--- a/.behavior/v2026_04_16.fix-keyrack-failure/refs/template.[feedback].v1.[given].by_human.md
+++ b/.behavior/v2026_04_16.fix-keyrack-failure/refs/template.[feedback].v1.[given].by_human.md
@@ -1,0 +1,27 @@
+emit your response to the feedback into
+- .behavior/v2026_04_16.fix-keyrack-failure/$BEHAVIOR_REF_NAME.[feedback].v$FEEDBACK_VERSION.[taken].by_robot.md
+
+1. emit your response checklist
+2. exec your response plan
+3. emit your response checkoffs into the checklist
+
+---
+
+first, bootup your mechanics briefs again
+
+npx rhachet roles boot --repo ehmpathy --role mechanic
+
+---
+---
+---
+
+
+# blocker.1
+
+---
+
+# nitpick.2
+
+---
+
+# blocker.3

--- a/.behavior/v2026_04_16.fix-keyrack-failure/review/self/for.1.vision._.r1.has-questioned-assumptions.md
+++ b/.behavior/v2026_04_16.fix-keyrack-failure/review/self/for.1.vision._.r1.has-questioned-assumptions.md
@@ -1,0 +1,110 @@
+# self review: has-questioned-assumptions
+
+## assumption 1: PING command is sufficient to verify daemon health
+
+**what do we assume without evidence?**
+that a PING command will exercise the same code path that fails (getSocketPeerPid → ss lookup).
+
+**what evidence supports this?**
+the daemon verifies caller session on every command via `verifyCallerLoginSession`. PING would trigger this verification.
+
+**what if the opposite were true?**
+if PING didn't use verifyCallerLoginSession, it wouldn't catch the failure. but all commands use this verification — it's the security model.
+
+**did the wisher say this, or did we infer it?**
+inferred. the wish says "verify daemon health" but doesn't specify how.
+
+**what exceptions exist?**
+could bypass verification for PING. but that would defeat the purpose — we want to test the exact code path that fails.
+
+**verdict: holds** — PING must use verifyCallerLoginSession to catch the failure.
+
+---
+
+## assumption 2: ss lookup failure is daemon's fault, not systemic
+
+**what do we assume without evidence?**
+that a fresh daemon will not have the same ss lookup failure.
+
+**what evidence supports this?**
+the failure happens when daemon state diverges from kernel state. a fresh daemon would have fresh socket, fresh inode.
+
+**what if the opposite were true?**
+if ss failure is systemic (e.g., ss command broken, permissions), fresh daemon would also fail. this would cause infinite restart loop.
+
+**did the wisher say this, or did we infer it?**
+inferred. the error message suggests stale daemon, but we haven't proven fresh daemon works.
+
+**what exceptions exist?**
+- ss could be absent or broken (rare, but possible)
+- kernel could be in weird state (namespace issues)
+- permissions could block ss
+
+**mitigation:**
+the vision already handles this: "fresh daemon also fails → propagate error (not a stale daemon issue)"
+
+if health check fails on fresh daemon, we propagate the error instead of looped retry.
+
+**verdict: holds** — but implementation must limit retries to prevent infinite loop.
+
+---
+
+## assumption 3: fresh daemon spawn will succeed after kill
+
+**what do we assume without evidence?**
+that kill of old daemon followed by spawn of new one will work.
+
+**what evidence supports this?**
+`findsertKeyrackDaemon` already has spawn logic. the daemon start is independent of the old daemon state.
+
+**what if the opposite were true?**
+if socket file persists after daemon dies, spawn could fail with EADDRINUSE. but spawn already handles this — it removes stale socket files.
+
+**did the wisher say this, or did we infer it?**
+inferred. the wish implies this flow but doesn't specify.
+
+**what exceptions exist?**
+- socket file locked by another process
+- permissions on socket directory changed
+- disk full (can't create socket file)
+
+**mitigation:**
+spawn already handles ENOENT and ECONNREFUSED. other failures would propagate as errors.
+
+**verdict: holds** — spawn logic is robust.
+
+---
+
+## assumption 4 (hidden): we should kill the unhealthy daemon
+
+**what do we assume without evidence?**
+that the correct response to unhealthy daemon is to kill it and spawn fresh.
+
+**what evidence supports this?**
+the alternative (leave unhealthy daemon) means user commands continue to fail. kill and restart is the standard daemon recovery pattern.
+
+**what if the opposite were true?**
+could try to "heal" the daemon instead of kill. but there's no heal operation — the daemon is just a process with in-memory state.
+
+**did the wisher say this, or did we infer it?**
+wisher said "findsert a new healthy daemon if extant is unhealthy". this implies replacement, not heal.
+
+**what exceptions exist?**
+kill of daemon loses cached credentials. user would need to re-unlock. but if daemon is unhealthy, credentials are inaccessible anyway.
+
+**verdict: holds** — kill and restart is correct.
+
+---
+
+## summary
+
+all assumptions hold:
+1. PING uses same verification path — catches the failure
+2. ss failure is daemon-specific — fresh daemon has fresh socket
+3. spawn succeeds after kill — spawn logic handles stale sockets
+4. kill is correct response — no alternative for unhealthy daemon
+
+one implementation note surfaced:
+- must limit retries to prevent infinite loop if failure is systemic
+
+no issues that block progress. ready to proceed.

--- a/.behavior/v2026_04_16.fix-keyrack-failure/review/self/for.1.vision._.r1.has-questioned-requirements.md
+++ b/.behavior/v2026_04_16.fix-keyrack-failure/review/self/for.1.vision._.r1.has-questioned-requirements.md
@@ -1,0 +1,91 @@
+# self review: has-questioned-requirements
+
+## requirement 1: deep health check via PING command
+
+**who said this was needed?**
+the user encountered the failure. the wish document captures the observed behavior.
+
+**what evidence supports this?**
+the error trace shows:
+- daemon socket accepted connection (TCP handshake succeeded)
+- daemon command failed when `ss -xp` could not find socket inode
+- `isDaemonReachable` returned true because it only checks TCP handshake
+
+**what if we didn't do this?**
+users would have to manually kill stale daemons. the error message gives no hint that this is the fix.
+
+**is scope too large, too small, or misdirected?**
+scope is appropriate. the fix is internal to `findsertKeyrackDaemon` — no contract changes needed.
+
+**could we achieve the goal in a simpler way?**
+
+considered alternatives:
+
+| alternative | pros | cons |
+|-------------|------|------|
+| retry on failure at call site | no new command needed | error handlers scattered across callers |
+| make ss lookup more resilient | addresses root cause | ss behavior is external, can't control |
+| catch error in daemonAccessUnlock, restart daemon, retry | single retry point | complex, hides failure mode |
+| **deep health check in findsert** | proactive, single place | requires PING command |
+
+the proactive approach (deep health check) is simplest:
+- single point of health verification
+- callers don't need retry logic
+- failure detected before user command runs
+
+**verdict: holds** — deep health check via PING is the right approach.
+
+---
+
+## requirement 2: automatic recovery by spawn fresh daemon
+
+**who said this was needed?**
+implied by the wish: "findsert a new healthy daemon if the extant one is unhealthy"
+
+**what evidence supports this?**
+the alternative (manual intervention) is poor UX. daemons are implementation detail; users shouldn't know they exist.
+
+**what if we didn't do this?**
+we could error with a hint like "run `rhx keyrack daemon prune`". but this exposes internals and adds friction.
+
+**is scope too large, too small, or misdirected?**
+appropriate. findsert already handles daemon spawn; this extends it to handle unhealthy-to-healthy transition.
+
+**could we achieve the goal in a simpler way?**
+no. if we detect unhealthy daemon, we must either:
+- tell user to fix it (poor UX)
+- fix it automatically (good UX)
+
+**verdict: holds** — automatic recovery is the right choice.
+
+---
+
+## requirement 3: no contract changes
+
+**who said this was needed?**
+design choice in vision: "no contract change"
+
+**what evidence supports this?**
+the issue is internal health detection. the public contract (`findsertKeyrackDaemon`) doesn't need new parameters.
+
+**what if we didn't do this?**
+could add `options.forceHealthCheck` or similar. but why would caller ever NOT want health check?
+
+**is scope too large, too small, or misdirected?**
+appropriate. callers want "give me a functional daemon" — implementation details are internal.
+
+**could we achieve the goal in a simpler way?**
+yes, this IS the simpler way. no contract change = no caller updates needed.
+
+**verdict: holds** — no contract change is correct.
+
+---
+
+## summary
+
+all requirements hold:
+1. deep health check via PING — addresses root cause at right layer
+2. automatic recovery — good UX, hides internal complexity
+3. no contract changes — simpler integration, backwards compatible
+
+no issues found. ready to proceed.

--- a/.behavior/v2026_04_16.fix-keyrack-failure/review/self/for.1.vision._.r2.has-questioned-assumptions.md
+++ b/.behavior/v2026_04_16.fix-keyrack-failure/review/self/for.1.vision._.r2.has-questioned-assumptions.md
@@ -1,0 +1,177 @@
+# self review r2: has-questioned-assumptions
+
+deeper pass. what did I miss in r1?
+
+## hidden assumption: PING must verify caller session
+
+**what do we assume?**
+that the PING command will use `verifyCallerLoginSession`, same as other commands.
+
+**why might this not hold?**
+we could implement PING to skip verification — a "dumb echo" that just proves the process is alive.
+
+**what if opposite were true?**
+a dumb PING would NOT catch the ss lookup failure. the daemon could PONG successfully, but still fail on UNLOCK because that command does verify.
+
+**verdict: design requirement surfaced**
+
+PING MUST call verifyCallerLoginSession. this is not automatic — it must be explicitly implemented this way.
+
+**action:** update vision to clarify: "health check must exercise same verification path as real commands"
+
+---
+
+## hidden assumption: one retry is sufficient
+
+**what do we assume?**
+that if fresh daemon also fails health check, we should propagate error.
+
+**why might this not hold?**
+could be transient issue that requires multiple retries. or could need backoff.
+
+**what if opposite were true?**
+infinite retry loop would hang the CLI. but zero retries (current plan) might fail on transient issues.
+
+**verdict: holds but clarify**
+
+one retry is correct for this failure mode:
+- if old daemon fails PING → spawn fresh
+- if fresh daemon fails PING → error (systemic issue, not stale daemon)
+
+two spawns would mask systemic issues. the vision handles this correctly.
+
+---
+
+## hidden assumption: health check should be proactive, not reactive
+
+**what do we assume?**
+that we should check health BEFORE use (proactive), not AFTER failure (reactive).
+
+**why might this not hold?**
+reactive approach would:
+1. try command
+2. on failure, kill daemon, spawn fresh, retry
+3. if retry fails, error
+
+**what if opposite were true (reactive)?**
+pros:
+- no latency on happy path (daemon is usually healthy)
+- simpler: no new PING command needed
+
+cons:
+- error bubbles up to caller before retry
+- caller might need retry logic
+- user might see transient error before success
+
+**verdict: proactive is correct**
+
+proactive catches failure before user command runs. user never sees the error. this is better UX.
+
+but this is a design choice worth a note — reactive would also work.
+
+---
+
+## hidden assumption: kill old daemon is safe
+
+**what do we assume?**
+that we can kill the unhealthy daemon without consequences.
+
+**why might this not hold?**
+- daemon holds cached credentials
+- other processes might be mid-command to same daemon
+- socket file might be left behind
+
+**what if opposite were true?**
+if we can't safely kill, we'd need:
+- graceful shutdown (QUIT command)
+- wait for in-flight commands
+- cleanup socket file
+
+**verdict: holds**
+
+- cached credentials: if daemon is unhealthy, they're inaccessible anyway
+- mid-command: same process, so sequential; no concurrency concern
+- socket file: spawn already handles stale socket cleanup
+
+---
+
+## hidden assumption: health check latency is acceptable
+
+**what do we assume?**
+that PING adds acceptable latency to findsert.
+
+**why might this not hold?**
+if PING adds 100ms, every `keyrack unlock` gets 100ms slower.
+
+**what if opposite were true?**
+could skip health check if daemon was used recently (TTL cache). but adds complexity.
+
+**verdict: holds**
+
+PING is local unix socket call. latency should be <10ms. acceptable for the reliability gained.
+
+---
+
+## what did r1 miss?
+
+r1 covered the obvious assumptions. r2 surfaced:
+
+1. **PING must verify** — not automatic, must be explicitly designed this way
+2. **proactive vs reactive** — design choice, proactive is correct but worth a note in design
+3. **health check latency** — acceptable for local socket
+
+## action items from r2
+
+1. update vision: clarify PING must use verifyCallerLoginSession
+2. note proactive choice in vision
+
+---
+
+## fixes applied
+
+### issue 1: PING must verify caller session (hidden assumption)
+
+**found:** vision assumed PING would verify caller session, but this is a design choice, not automatic.
+
+**fixed:** added "design decisions" section to vision with explicit requirement:
+- PING must call `verifyCallerLoginSession`
+- health check must exercise same verification path as real commands
+
+### issue 2: proactive vs reactive not documented (design choice)
+
+**found:** vision assumed proactive health check without documenting why.
+
+**fixed:** added to "design decisions" section:
+- proactive health check, not reactive
+- rationale: user never sees transient errors
+
+### issue 3: PING retry needed (surfaced in deeper pass)
+
+**found:** kill on single PING failure is aggressive. transient ss issues could cause unnecessary restarts.
+
+**fixed:** added to "design decisions" section:
+- PING retry before kill
+- try PING, wait 100ms, retry once before concluding unhealthy
+
+### issue 4: PING timeout not specified
+
+**found:** no timeout decision documented.
+
+**fixed:** added to "design decisions" section:
+- PING timeout = 1000ms
+
+### issue 5: error message guidance
+
+**found:** no actionable hint when fresh daemon also fails.
+
+**fixed:** updated edge cases table:
+- "propagate error with actionable hint (e.g., check if ss command works)"
+
+### non-issues (hold as-is)
+
+| assumption | why it holds |
+|------------|-------------|
+| one daemon spawn retry | two spawns would mask systemic issues; fresh-daemon-also-fails = propagate error |
+| kill daemon is safe | cached creds inaccessible anyway; no concurrency; spawn handles stale socket |
+| latency acceptable | local unix socket <10ms; reliability worth small latency |
+| cached credentials lost on kill | unreliable daemon is worse than re-unlock; user can trust fresh daemon |

--- a/.behavior/v2026_04_16.fix-keyrack-failure/review/self/for.1.vision._.r2.has-questioned-questions.md
+++ b/.behavior/v2026_04_16.fix-keyrack-failure/review/self/for.1.vision._.r2.has-questioned-questions.md
@@ -1,0 +1,69 @@
+# self review: has-questioned-questions
+
+triage the open questions in the vision.
+
+---
+
+## question 1: should we log when we detect and replace an unhealthy daemon?
+
+**triage:** can be answered via logic now
+
+**answer:** YES
+
+rationale:
+- observability is critical for debug
+- silent recovery is good for UX, but engineers need to know what happened
+- log at INFO: "daemon unhealthy, restarted"
+- log at DEBUG: reason (PING timeout, PING error, etc.)
+
+**mark:** [answered]
+
+---
+
+## question 2: should we attempt graceful shutdown of old daemon or just spawn over it?
+
+**triage:** can be answered via logic + extant code
+
+**answer:** spawn over it (no graceful shutdown)
+
+rationale:
+- extant `spawnKeyrackDaemonBackground` already handles stale socket cleanup
+- if daemon is unhealthy, it can't serve requests anyway
+- kill of process adds complexity (need to find PID, send SIGTERM, wait)
+- orphan daemon will die naturally when socket is replaced
+
+**mark:** [answered]
+
+---
+
+## question 3: is there a specific command we should use for health check, or create a new PING command?
+
+**triage:** can be answered via logic
+
+**answer:** create new PING command
+
+rationale:
+- must verify caller session (per design decision)
+- extant commands (GET, UNLOCK) have side effects or require args
+- PING is lightweight, single purpose: verify daemon can process commands
+- response can include daemon metadata (uptime, version) for future use
+
+**mark:** [answered]
+
+---
+
+## summary
+
+| question | triage | resolution |
+|----------|--------|------------|
+| log on daemon restart? | [answered] | yes, INFO level |
+| graceful shutdown? | [answered] | no, spawn over |
+| which command for health check? | [answered] | create PING |
+
+all questions resolved. no wisher input needed. no research needed.
+
+---
+
+## vision update
+
+updated "questions to validate" section with answers.

--- a/.behavior/v2026_04_16.fix-keyrack-failure/review/self/for.1.vision._.r3.has-questioned-assumptions.md
+++ b/.behavior/v2026_04_16.fix-keyrack-failure/review/self/for.1.vision._.r3.has-questioned-assumptions.md
@@ -1,0 +1,129 @@
+# self review r3: has-questioned-assumptions
+
+third pass. paused. breathed. let me look with fresh eyes.
+
+## what did r2 miss?
+
+r2 found implementation assumptions (PING must verify, proactive vs reactive). but I didn't question the core STRATEGY.
+
+---
+
+## hidden assumption: kill daemon on single PING failure is correct
+
+**what do we assume?**
+one PING failure means daemon is unhealthy and should be killed.
+
+**why might this not hold?**
+PING could fail due to:
+- transient ss race condition (would succeed on retry)
+- momentary system load (ss slow to respond)
+- one-off kernel hiccup
+
+**what if opposite were true?**
+could retry PING 2-3 times before concluding daemon is unhealthy.
+
+**verdict: issue found**
+
+kill on first failure is aggressive. a single PING retry would catch transient issues without adding significant latency.
+
+**action:** update vision — add retry logic to health check design.
+
+---
+
+## hidden assumption: cached credentials are already lost
+
+**what do we assume?**
+if daemon is unhealthy, cached credentials are inaccessible, so kill loses no value.
+
+**why might this not hold?**
+if failure is intermittent (ss works 50% of the time), some commands might succeed. user might not realize daemon is flaky.
+
+**what if opposite were true?**
+user might prefer "flaky daemon that sometimes works" over "fresh daemon that requires re-unlock".
+
+**verdict: holds**
+
+an intermittent daemon is worse than a fresh one:
+- unpredictable failures are frustrating
+- user can't trust the daemon
+- re-unlock is better than intermittent failures
+
+but this assumption is worth a note — we choose "reliable over available".
+
+---
+
+## hidden assumption: PING timeout is obvious
+
+**what do we assume?**
+PING will have a reasonable timeout.
+
+**why might this not hold?**
+- too short timeout: kill healthy but slow daemon
+- too long timeout: user waits for unhealthy daemon
+
+**what if opposite were true?**
+need explicit timeout decision.
+
+**verdict: issue found**
+
+need to specify timeout. suggest: 1000ms — long enough for slow daemon, short enough for UX.
+
+**action:** add timeout to design decisions.
+
+---
+
+## hidden assumption: fresh daemon always starts clean
+
+**what do we assume?**
+spawned daemon will be healthy because it's fresh.
+
+**why might this not hold?**
+if problem is:
+- ss command broken
+- permission issue
+- code bug in getSocketPeerPid
+
+fresh daemon would have same issue.
+
+**verdict: already addressed**
+
+vision covers this: "fresh daemon also fails → propagate error". good.
+
+but could clarify: after propagate error, user should get actionable hint (e.g., "check ss command permissions").
+
+**action:** add error message guidance to vision.
+
+---
+
+## fixes applied
+
+### issue 1: PING retry needed
+
+**found:** single PING failure might be transient; kill is aggressive.
+
+**fix:** update vision to add PING retry:
+- try PING
+- if fails, wait 100ms, retry once
+- if still fails, kill and respawn
+
+### issue 2: PING timeout not specified
+
+**found:** no timeout decision documented.
+
+**fix:** add to design decisions: "PING timeout = 1000ms"
+
+### issue 3: error message for fresh-daemon-fails case
+
+**found:** no guidance on what user should do if fresh daemon also fails.
+
+**fix:** add to edge cases: error should include actionable hint.
+
+---
+
+## non-issues (hold as-is)
+
+| assumption | why it holds |
+|------------|-------------|
+| cached credentials lost | unreliable daemon is worse than re-unlock |
+| fresh daemon starts clean | ss issues are rare; propagate if systemic |
+| proactive over reactive | user never sees transient error |

--- a/.behavior/v2026_04_16.fix-keyrack-failure/review/self/for.1.vision._.r3.has-questioned-questions.md
+++ b/.behavior/v2026_04_16.fix-keyrack-failure/review/self/for.1.vision._.r3.has-questioned-questions.md
@@ -1,0 +1,91 @@
+# self review r3: has-questioned-questions
+
+deeper pass. are there questions I missed? are my answers sound?
+
+---
+
+## review of question 1: log on daemon restart
+
+**my answer:** YES, log at INFO level
+
+**is this sound?**
+- INFO level appropriate for user-visible events
+- DEBUG level for internal details (why health check failed)
+- consistent with log practices in keyrack
+
+**any counterarguments?**
+- could argue for WARN since daemon restart is unusual
+- but WARN implies actionable issue; daemon restart is handled automatically
+
+**verdict:** answer holds. INFO is correct level.
+
+---
+
+## review of question 2: graceful shutdown vs spawn over
+
+**my answer:** spawn over, no graceful shutdown
+
+**is this sound?**
+- extant code (`spawnKeyrackDaemonBackground`) cleans up stale sockets
+- orphan daemon has no socket, can't receive commands, will eventually exit
+- no data loss risk (daemon caches credentials in memory, but unhealthy daemon's cache is inaccessible anyway)
+
+**any counterarguments?**
+- orphan daemon consumes resources until it exits
+- if many restarts, many orphans
+
+**mitigation:**
+- daemon has TTL on credentials; when credentials expire, daemon exits
+- resource consumption is minimal (idle process)
+
+**verdict:** answer holds. spawn over is simpler and safe.
+
+---
+
+## review of question 3: create PING command
+
+**my answer:** create new PING command
+
+**is this sound?**
+- PING must verify caller session (per design decision)
+- extant commands not suitable:
+  - GET requires key arg
+  - UNLOCK requires credentials
+  - STATUS might work but doesn't verify caller (if it exists)
+- PING is explicit: "am I healthy?"
+
+**any counterarguments?**
+- adds new command to daemon protocol
+- maintenance burden
+
+**mitigation:**
+- PING is simple (no args, returns OK or error)
+- single purpose = easy to maintain
+
+**verdict:** answer holds. create PING.
+
+---
+
+## are there questions not yet asked?
+
+reviewed vision for implicit questions:
+
+| implicit question | triage |
+|-------------------|--------|
+| how do we measure "fewer failures"? | [answered] - observability via logs; not a separate metric needed |
+| what if recovery fails repeatedly? | [answered] - propagate error after fresh daemon also fails |
+| should we limit restart rate? | [answered] - one restart per findsert; if fresh fails, error out |
+
+no questions absent from the vision.
+
+---
+
+## fixes applied
+
+no issues found. all questions properly triaged.
+
+| question | answer | why it holds |
+|----------|--------|--------------|
+| log level | INFO | user-visible event, not actionable WARN |
+| graceful shutdown | no | extant code handles; orphan is safe |
+| command | create PING | explicit purpose, must verify caller |

--- a/blackbox/cli/__snapshots__/keyrack.status.env-filter.acceptance.test.ts.snap
+++ b/blackbox/cli/__snapshots__/keyrack.status.env-filter.acceptance.test.ts.snap
@@ -1,0 +1,107 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`keyrack status --env given: [case1] invalid --env value when: [t0] status is called with invalid env then: stderr matches snapshot 1`] = `
+"
+BadRequestError: invalid --env: must be one of sudo, prod, prep, test, all
+
+[args] keyrack,status,--env,invalid
+
+"
+`;
+
+exports[`keyrack status --env given: [case2] status --env filters keys to requested env when: [t0] status without --env shows all keys then: stdout matches snapshot 1`] = `
+{
+  "keys": [
+    {
+      "env": "sudo",
+      "expiresAt": "__REDACTED__",
+      "org": "@all",
+      "slug": "@all.sudo.SUDO_SECRET",
+      "ttlLeftMs": "__REDACTED__",
+    },
+  ],
+  "owner": null,
+  "recipients": [
+    {
+      "addedAt": "__REDACTED__",
+      "label": "default",
+      "mech": "age",
+      "pubkey": "age1qzd7j8sdwzn8a75lsxyw2sx7e7rn7g6w3a7x08m95pxan3c3u9fq7c6xuf",
+    },
+  ],
+  "socketPath": "__REDACTED__",
+}
+`;
+
+exports[`keyrack status --env given: [case2] status --env filters keys to requested env when: [t1] status --env sudo shows only sudo keys then: stdout matches snapshot 1`] = `
+{
+  "keys": [
+    {
+      "env": "sudo",
+      "expiresAt": "__REDACTED__",
+      "org": "@all",
+      "slug": "@all.sudo.SUDO_SECRET",
+      "ttlLeftMs": "__REDACTED__",
+    },
+  ],
+  "owner": null,
+  "recipients": [
+    {
+      "addedAt": "__REDACTED__",
+      "label": "default",
+      "mech": "age",
+      "pubkey": "age1qzd7j8sdwzn8a75lsxyw2sx7e7rn7g6w3a7x08m95pxan3c3u9fq7c6xuf",
+    },
+  ],
+  "socketPath": "__REDACTED__",
+}
+`;
+
+exports[`keyrack status --env given: [case2] status --env filters keys to requested env when: [t2] status --env test returns empty (no test keys) then: stdout matches snapshot 1`] = `
+{
+  "keys": [],
+  "owner": null,
+  "recipients": [
+    {
+      "addedAt": "__REDACTED__",
+      "label": "default",
+      "mech": "age",
+      "pubkey": "age1qzd7j8sdwzn8a75lsxyw2sx7e7rn7g6w3a7x08m95pxan3c3u9fq7c6xuf",
+    },
+  ],
+  "socketPath": "__REDACTED__",
+}
+`;
+
+exports[`keyrack status --env given: [case3] status --env shows hint for non-sudo envs with keys when: [t0] status --env test (no keys in test, but keys in prep) then: stdout matches snapshot 1`] = `
+"
+🔐 keyrack status
+   ├─ owner: (default)
+   ├─ recipients:
+   │  └─ default (age)
+   └─ daemon: active ✨
+      └─ (no keys in --env test, try --env prep)
+
+"
+`;
+
+exports[`keyrack status --env given: [case4] status --env shows no hint when only sudo keys exist when: [t0] status --env test (no keys in test, only sudo keys exist) then: stdout matches snapshot 1`] = `
+"
+🔐 keyrack status
+   ├─ owner: (default)
+   ├─ recipients:
+   │  └─ default (age)
+   └─ daemon: active ✨
+      └─ (no keys in --env test)
+
+"
+`;
+
+exports[`keyrack status --env given: [case5] status with --env in isolated env (daemon inactive) when: [t0] status is called with --env test (daemon inactive) then: stdout matches snapshot 1`] = `
+"
+🔐 keyrack status
+   └─ daemon: not found
+      └─ run \`rhx keyrack unlock\` to start session
+
+"
+`;

--- a/blackbox/cli/keyrack.status.env-filter.acceptance.test.ts
+++ b/blackbox/cli/keyrack.status.env-filter.acceptance.test.ts
@@ -1,0 +1,384 @@
+import { mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+import { given, then, useBeforeAll, useThen, when } from 'test-fns';
+
+import {
+  genTestTempRepo,
+  TEST_SSH_AGE_RECIPIENT,
+} from '../.test/infra/genTestTempRepo';
+import { invokeRhachetCliBinary } from '../.test/infra/invokeRhachetCliBinary';
+import { killKeyrackDaemonForTests } from '../.test/infra/killKeyrackDaemonForTests';
+
+/**
+ * .what = acceptance tests for keyrack status --env filter
+ * .why = prove behavior of env filter and hints
+ */
+describe('keyrack status --env', () => {
+  // kill any stale daemon to ensure fresh code is used
+  beforeAll(() => {
+    killKeyrackDaemonForTests({ owner: null });
+  });
+
+  given('[case1] invalid --env value', () => {
+    const repo = useBeforeAll(async () =>
+      genTestTempRepo({ fixture: 'minimal' }),
+    );
+
+    when('[t0] status is called with invalid env', () => {
+      const result = useThen('command fails with error', () =>
+        invokeRhachetCliBinary({
+          args: ['keyrack', 'status', '--env', 'invalid'],
+          cwd: repo.path,
+          env: { HOME: repo.path },
+          logOnError: false,
+        }),
+      );
+
+      then('exit code is non-zero', () => {
+        expect(result.status).not.toBe(0);
+      });
+
+      then('error mentions valid env values', () => {
+        expect(result.stderr).toContain('invalid --env');
+        expect(result.stderr).toMatch(/prod|prep|test|all|sudo/);
+      });
+
+      then('stderr matches snapshot', () => {
+        expect(result.stderr).toMatchSnapshot();
+      });
+    });
+  });
+
+  given('[case2] status --env filters keys to requested env', () => {
+    // kill daemon for clean state
+    beforeAll(() => killKeyrackDaemonForTests({ owner: null }));
+
+    const repo = useBeforeAll(async () => {
+      const r = await genTestTempRepo({ fixture: 'minimal' });
+      // init keyrack
+      await invokeRhachetCliBinary({
+        args: ['keyrack', 'init'],
+        cwd: r.path,
+        env: { HOME: r.path },
+      });
+      return r;
+    });
+
+    // set and unlock a key in env=sudo
+    useBeforeAll(async () =>
+      invokeRhachetCliBinary({
+        args: [
+          'keyrack',
+          'set',
+          '--key',
+          'SUDO_SECRET',
+          '--env',
+          'sudo',
+          '--vault',
+          'os.secure',
+          '--mech',
+          'PERMANENT_VIA_REPLICA',
+          '--vault-recipient',
+          TEST_SSH_AGE_RECIPIENT,
+          '--org',
+          '@all',
+          '--json',
+        ],
+        cwd: repo.path,
+        env: { HOME: repo.path },
+        stdin: 'sudo-secret\n',
+      }),
+    );
+
+    useBeforeAll(async () =>
+      invokeRhachetCliBinary({
+        args: ['keyrack', 'unlock', '--env', 'sudo', '--key', 'SUDO_SECRET'],
+        cwd: repo.path,
+        env: { HOME: repo.path },
+      }),
+    );
+
+    when('[t0] status without --env shows all keys', () => {
+      const result = useThen('status succeeds', () =>
+        invokeRhachetCliBinary({
+          args: ['keyrack', 'status', '--json'],
+          cwd: repo.path,
+          env: { HOME: repo.path },
+        }),
+      );
+
+      then('shows sudo key', () => {
+        const parsed = JSON.parse(result.stdout);
+        expect(parsed.keys.length).toBeGreaterThan(0);
+        expect(
+          parsed.keys.some((k: { slug: string }) =>
+            k.slug.includes('SUDO_SECRET'),
+          ),
+        ).toBe(true);
+      });
+
+      then('stdout matches snapshot', () => {
+        const parsed = JSON.parse(result.stdout);
+        // redact volatile fields
+        parsed.socketPath = '__REDACTED__';
+        for (const key of parsed.keys) {
+          key.expiresAt = '__REDACTED__';
+          key.ttlLeftMs = '__REDACTED__';
+        }
+        for (const recipient of parsed.recipients ?? []) {
+          recipient.addedAt = '__REDACTED__';
+        }
+        expect(parsed).toMatchSnapshot();
+      });
+    });
+
+    when('[t1] status --env sudo shows only sudo keys', () => {
+      const result = useThen('status succeeds', () =>
+        invokeRhachetCliBinary({
+          args: ['keyrack', 'status', '--env', 'sudo', '--json'],
+          cwd: repo.path,
+          env: { HOME: repo.path },
+        }),
+      );
+
+      then('shows sudo key', () => {
+        const parsed = JSON.parse(result.stdout);
+        expect(parsed.keys.length).toBeGreaterThan(0);
+        expect(parsed.keys.every((k: { env: string }) => k.env === 'sudo')).toBe(
+          true,
+        );
+      });
+
+      then('stdout matches snapshot', () => {
+        const parsed = JSON.parse(result.stdout);
+        // redact volatile fields
+        parsed.socketPath = '__REDACTED__';
+        for (const key of parsed.keys) {
+          key.expiresAt = '__REDACTED__';
+          key.ttlLeftMs = '__REDACTED__';
+        }
+        for (const recipient of parsed.recipients ?? []) {
+          recipient.addedAt = '__REDACTED__';
+        }
+        expect(parsed).toMatchSnapshot();
+      });
+    });
+
+    when('[t2] status --env test returns empty (no test keys)', () => {
+      const result = useThen('status succeeds', () =>
+        invokeRhachetCliBinary({
+          args: ['keyrack', 'status', '--env', 'test', '--json'],
+          cwd: repo.path,
+          env: { HOME: repo.path },
+        }),
+      );
+
+      then('keys array is empty', () => {
+        const parsed = JSON.parse(result.stdout);
+        expect(parsed.keys).toEqual([]);
+      });
+
+      then('stdout matches snapshot', () => {
+        const parsed = JSON.parse(result.stdout);
+        // redact volatile fields
+        parsed.socketPath = '__REDACTED__';
+        for (const recipient of parsed.recipients ?? []) {
+          recipient.addedAt = '__REDACTED__';
+        }
+        expect(parsed).toMatchSnapshot();
+      });
+    });
+  });
+
+  given('[case3] status --env shows hint for non-sudo envs with keys', () => {
+    // kill daemon for clean state
+    beforeAll(() => killKeyrackDaemonForTests({ owner: null }));
+
+    const repo = useBeforeAll(async () => {
+      const r = await genTestTempRepo({ fixture: 'minimal' });
+
+      // create keyrack.yml that declares a key in env.prep (required for non-sudo unlock)
+      const keyrackYml = `org: testorg
+env.prep:
+  - PREP_SECRET
+`;
+      mkdirSync(join(r.path, '.agent'), { recursive: true });
+      writeFileSync(join(r.path, '.agent', 'keyrack.yml'), keyrackYml);
+
+      // init keyrack
+      await invokeRhachetCliBinary({
+        args: ['keyrack', 'init'],
+        cwd: r.path,
+        env: { HOME: r.path },
+      });
+      return r;
+    });
+
+    // set and unlock a key in env=prep (non-sudo, will appear in hints)
+    useBeforeAll(async () =>
+      invokeRhachetCliBinary({
+        args: [
+          'keyrack',
+          'set',
+          '--key',
+          'PREP_SECRET',
+          '--env',
+          'prep',
+          '--vault',
+          'os.secure',
+          '--mech',
+          'PERMANENT_VIA_REPLICA',
+          '--vault-recipient',
+          TEST_SSH_AGE_RECIPIENT,
+          '--json',
+        ],
+        cwd: repo.path,
+        env: { HOME: repo.path },
+        stdin: 'prep-secret-value\n',
+      }),
+    );
+
+    useBeforeAll(async () =>
+      invokeRhachetCliBinary({
+        args: ['keyrack', 'unlock', '--env', 'prep', '--key', 'PREP_SECRET'],
+        cwd: repo.path,
+        env: { HOME: repo.path },
+      }),
+    );
+
+    when('[t0] status --env test (no keys in test, but keys in prep)', () => {
+      const result = useThen('status succeeds', () =>
+        invokeRhachetCliBinary({
+          args: ['keyrack', 'status', '--env', 'test'],
+          cwd: repo.path,
+          env: { HOME: repo.path },
+        }),
+      );
+
+      then('exit code is 0', () => {
+        expect(result.status).toBe(0);
+      });
+
+      then('output shows no keys in test with hint to try prep', () => {
+        // hint format: "(no keys in --env test, try --env prep)"
+        expect(result.stdout).toContain('no keys in --env test');
+        expect(result.stdout).toContain('try --env prep');
+      });
+
+      then('stdout matches snapshot', () => {
+        expect(result.stdout).toMatchSnapshot();
+      });
+    });
+  });
+
+  given('[case4] status --env shows no hint when only sudo keys exist', () => {
+    // kill daemon for clean state
+    beforeAll(() => killKeyrackDaemonForTests({ owner: null }));
+
+    const repo = useBeforeAll(async () => {
+      const r = await genTestTempRepo({ fixture: 'minimal' });
+      // init keyrack
+      await invokeRhachetCliBinary({
+        args: ['keyrack', 'init'],
+        cwd: r.path,
+        env: { HOME: r.path },
+      });
+      return r;
+    });
+
+    // set and unlock a key ONLY in env=sudo (sudo is filtered from hints)
+    useBeforeAll(async () =>
+      invokeRhachetCliBinary({
+        args: [
+          'keyrack',
+          'set',
+          '--key',
+          'ONLY_SUDO_KEY',
+          '--env',
+          'sudo',
+          '--vault',
+          'os.secure',
+          '--mech',
+          'PERMANENT_VIA_REPLICA',
+          '--vault-recipient',
+          TEST_SSH_AGE_RECIPIENT,
+          '--org',
+          '@all',
+          '--json',
+        ],
+        cwd: repo.path,
+        env: { HOME: repo.path },
+        stdin: 'only-sudo-secret\n',
+      }),
+    );
+
+    useBeforeAll(async () =>
+      invokeRhachetCliBinary({
+        args: ['keyrack', 'unlock', '--env', 'sudo', '--key', 'ONLY_SUDO_KEY'],
+        cwd: repo.path,
+        env: { HOME: repo.path },
+      }),
+    );
+
+    when('[t0] status --env test (no keys in test, only sudo keys exist)', () => {
+      const result = useThen('status succeeds', () =>
+        invokeRhachetCliBinary({
+          args: ['keyrack', 'status', '--env', 'test'],
+          cwd: repo.path,
+          env: { HOME: repo.path },
+        }),
+      );
+
+      then('exit code is 0', () => {
+        expect(result.status).toBe(0);
+      });
+
+      then('output shows no keys in test WITHOUT hint (sudo is silent)', () => {
+        // sudo keys are filtered from hints, so no hint appears
+        expect(result.stdout).toContain('no keys in --env test');
+        expect(result.stdout).not.toContain('try --env');
+      });
+
+      then('stdout matches snapshot', () => {
+        expect(result.stdout).toMatchSnapshot();
+      });
+    });
+  });
+
+  given('[case5] status with --env in isolated env (daemon inactive)', () => {
+    const repo = useBeforeAll(async () => {
+      const r = await genTestTempRepo({ fixture: 'minimal' });
+      // init keyrack so we have valid config
+      await invokeRhachetCliBinary({
+        args: ['keyrack', 'init'],
+        cwd: r.path,
+        env: { HOME: r.path },
+      });
+      return r;
+    });
+
+    when('[t0] status is called with --env test (daemon inactive)', () => {
+      const result = useThen('command succeeds', () =>
+        invokeRhachetCliBinary({
+          args: ['keyrack', 'status', '--env', 'test'],
+          cwd: repo.path,
+          env: { HOME: repo.path },
+        }),
+      );
+
+      then('exit code is 0', () => {
+        expect(result.status).toBe(0);
+      });
+
+      then('output shows daemon not found', () => {
+        expect(result.stdout).toContain('daemon');
+        expect(result.stdout).toMatch(/not found/i);
+      });
+
+      then('stdout matches snapshot', () => {
+        expect(result.stdout).toMatchSnapshot();
+      });
+    });
+  });
+});

--- a/src/contract/cli/invokeKeyrack.ts
+++ b/src/contract/cli/invokeKeyrack.ts
@@ -1137,67 +1137,109 @@ export const invokeKeyrack = ({ program }: { program: Command }): void => {
       },
     );
 
-  // keyrack status [--owner owner]
+  // keyrack status [--owner owner] [--env env]
   keyrack
     .command('status')
     .description('show status of unlocked keys in daemon')
     .option('--owner <owner>', 'owner identity (e.g., mechanic, foreman)')
     .option('--for <owner>', 'alias for --owner')
+    .option('--env <env>', 'filter by env: prod, prep, test, all, or sudo')
     .option('--json', 'output as json (robot mode)')
-    .action(async (opts: { owner?: string; for?: string; json?: boolean }) => {
-      // --owner takes precedence; --for is alias
-      const owner = opts.owner ?? opts.for ?? null;
+    .action(
+      async (opts: {
+        owner?: string;
+        for?: string;
+        env?: string;
+        json?: boolean;
+      }) => {
+        // --owner takes precedence; --for is alias
+        const owner = opts.owner ?? opts.for ?? null;
 
-      // get status
-      const status = await getKeyrackStatus({ owner });
-
-      // output results
-      if (opts.json) {
-        console.log(JSON.stringify(status, null, 2));
-      } else {
-        console.log('');
-        console.log('🔐 keyrack status');
-        if (!status) {
-          console.log('   └─ daemon: not found');
-          console.log('      └─ run `rhx keyrack unlock` to start session');
-        } else {
-          // show owner
-          const ownerLabel = status.owner ?? '(default)';
-          console.log(`   ├─ owner: ${ownerLabel}`);
-
-          // show recipients
-          if (status.recipients.length > 0) {
-            console.log('   ├─ recipients:');
-            for (let i = 0; i < status.recipients.length; i++) {
-              const recipient = status.recipients[i]!;
-              const isLastRecipient = i === status.recipients.length - 1;
-              const prefix = isLastRecipient ? '   │  └─' : '   │  ├─';
-              console.log(`${prefix} ${recipient.label} (${recipient.mech})`);
-            }
-          }
-
-          // show daemon status
-          if (status.keys.length === 0) {
-            console.log('   └─ daemon: active ✨');
-            console.log('      └─ (no keys unlocked)');
-          } else {
-            console.log('   ├─ daemon: active ✨');
-            for (let i = 0; i < status.keys.length; i++) {
-              const key = status.keys[i]!;
-              const isLast = i === status.keys.length - 1;
-              const prefix = isLast ? '   └─' : '   ├─';
-              const indent = isLast ? '      ' : '   │  ';
-              const ttlMinutes = Math.round(key.ttlLeftMs / 1000 / 60);
-              console.log(`${prefix} ${key.slug}`);
-              console.log(`${indent}├─ env: ${key.env}`);
-              console.log(`${indent}├─ org: ${key.org}`);
-              console.log(`${indent}└─ expires in: ${ttlMinutes}m`);
-            }
-          }
+        // validate env if provided
+        if (opts.env && !isValidKeyrackEnv(opts.env)) {
+          throw new BadRequestError(
+            `invalid --env: must be one of ${KEYRACK_VALID_ENVS.join(', ')}`,
+          );
         }
-        console.log('');
-      }
-    });
+
+        // get status
+        const status = await getKeyrackStatus({ owner });
+
+        // filter keys by env if specified
+        const filteredKeys = opts.env
+          ? (status?.keys ?? []).filter((k) => k.env === opts.env)
+          : (status?.keys ?? []);
+
+        // compute hint for when no keys in filtered env
+        const getEnvHint = (): string | null => {
+          if (!opts.env) return null;
+          if (!status || status.keys.length === 0) return null;
+          // find other envs that have keys (exclude sudo from hints)
+          const otherEnvs = [...new Set(status.keys.map((k) => k.env))].filter(
+            (e) => e !== opts.env && e !== 'sudo',
+          );
+          if (otherEnvs.length === 0) return null;
+          return `try --env ${otherEnvs.join(' or --env ')}`;
+        };
+
+        // output results
+        if (opts.json) {
+          const output = status ? { ...status, keys: filteredKeys } : status;
+          console.log(JSON.stringify(output, null, 2));
+        } else {
+          console.log('');
+          console.log('🔐 keyrack status');
+          if (!status) {
+            console.log('   └─ daemon: not found');
+            console.log('      └─ run `rhx keyrack unlock` to start session');
+          } else {
+            // show owner
+            const ownerLabel = status.owner ?? '(default)';
+            console.log(`   ├─ owner: ${ownerLabel}`);
+
+            // show recipients
+            if (status.recipients.length > 0) {
+              console.log('   ├─ recipients:');
+              for (let i = 0; i < status.recipients.length; i++) {
+                const recipient = status.recipients[i]!;
+                const isLastRecipient = i === status.recipients.length - 1;
+                const prefix = isLastRecipient ? '   │  └─' : '   │  ├─';
+                console.log(`${prefix} ${recipient.label} (${recipient.mech})`);
+              }
+            }
+
+            // show daemon status
+            if (filteredKeys.length === 0) {
+              console.log('   └─ daemon: active ✨');
+              const envHint = getEnvHint();
+              if (opts.env && envHint) {
+                console.log(
+                  `      └─ (no keys in --env ${opts.env}, ${envHint})`,
+                );
+              } else if (opts.env) {
+                console.log(`      └─ (no keys in --env ${opts.env})`);
+              } else {
+                console.log('      └─ (no keys unlocked)');
+              }
+            } else {
+              console.log('   ├─ daemon: active ✨');
+              for (let i = 0; i < filteredKeys.length; i++) {
+                const key = filteredKeys[i]!;
+                const isLast = i === filteredKeys.length - 1;
+                const prefix = isLast ? '   └─' : '   ├─';
+                const indent = isLast ? '      ' : '   │  ';
+                const ttlMinutes = Math.round(key.ttlLeftMs / 1000 / 60);
+                console.log(`${prefix} ${key.slug}`);
+                console.log(`${indent}├─ env: ${key.env}`);
+                console.log(`${indent}├─ org: ${key.org}`);
+                console.log(`${indent}└─ expires in: ${ttlMinutes}m`);
+              }
+            }
+          }
+          console.log('');
+        }
+      },
+    );
 
   // keyrack list [--owner owner]
   keyrack

--- a/src/domain.operations/keyrack/daemon/svc/src/infra/getSocketPeerPid.test.ts
+++ b/src/domain.operations/keyrack/daemon/svc/src/infra/getSocketPeerPid.test.ts
@@ -1,0 +1,94 @@
+import { given, then, when } from 'test-fns';
+
+/**
+ * .what = unit tests for signed/unsigned inode conversion
+ * .why = prove the fix for socket inode lookup when inode > 2^31
+ *
+ * .note = the actual getSocketPeerPid function requires live sockets
+ * .note = these tests validate the math used in the signed conversion
+ */
+describe('getSocketPeerPid signed/unsigned conversion', () => {
+  const INT32_MAX = 2147483647; // 2^31 - 1
+  const UINT32_MAX = 4294967296; // 2^32
+
+  /**
+   * .what = convert unsigned inode to signed 32-bit representation
+   * .why = ss -xp displays socket identifiers as signed 32-bit integers
+   */
+  const asSignedInode = (unsignedInode: number): number =>
+    unsignedInode > INT32_MAX ? unsignedInode - UINT32_MAX : unsignedInode;
+
+  given('[case1] inode below INT32_MAX (positive in both)', () => {
+    when('[t0] inode is 12345', () => {
+      then('signed representation is same as unsigned', () => {
+        expect(asSignedInode(12345)).toBe(12345);
+      });
+    });
+
+    when('[t1] inode is exactly INT32_MAX', () => {
+      then('signed representation is same as unsigned', () => {
+        expect(asSignedInode(INT32_MAX)).toBe(INT32_MAX);
+      });
+    });
+  });
+
+  given('[case2] inode above INT32_MAX (negative in signed)', () => {
+    when('[t0] inode from POC: 2367234854', () => {
+      // from refs/poc.root-cause-investigation.md
+      // unsigned: 2367234854
+      // signed: 2367234854 - 4294967296 = -1927732442
+      then('signed representation is negative', () => {
+        expect(asSignedInode(2367234854)).toBe(-1927732442);
+      });
+    });
+
+    when('[t1] inode from POC: 2365553034', () => {
+      // from refs/poc.root-cause-investigation.md
+      // unsigned: 2365553034
+      // signed: 2365553034 - 4294967296 = -1929414262
+      then('signed representation matches ss output', () => {
+        expect(asSignedInode(2365553034)).toBe(-1929414262);
+      });
+    });
+
+    when('[t2] inode just above INT32_MAX', () => {
+      // INT32_MAX + 1 = 2147483648
+      // signed: 2147483648 - 4294967296 = -2147483648
+      then('wraps to minimum signed value', () => {
+        expect(asSignedInode(INT32_MAX + 1)).toBe(-2147483648);
+      });
+    });
+
+    when('[t3] inode at UINT32_MAX - 1', () => {
+      // 4294967295 (max unsigned 32-bit)
+      // signed: 4294967295 - 4294967296 = -1
+      then('wraps to -1', () => {
+        expect(asSignedInode(UINT32_MAX - 1)).toBe(-1);
+      });
+    });
+  });
+
+  given('[case3] grep pattern generation', () => {
+    /**
+     * .what = generate grep pattern for inode lookup
+     * .why = must match either unsigned or signed representation
+     */
+    const asGrepPattern = (inode: string): string => {
+      const inodeNum = parseInt(inode, 10);
+      const signedInode = asSignedInode(inodeNum);
+      return inodeNum > INT32_MAX ? `(${inode}|${signedInode})` : inode;
+    };
+
+    when('[t0] inode below INT32_MAX', () => {
+      then('pattern is just the inode', () => {
+        expect(asGrepPattern('12345')).toBe('12345');
+      });
+    });
+
+    when('[t1] inode above INT32_MAX', () => {
+      then('pattern includes both unsigned and signed', () => {
+        expect(asGrepPattern('2367234854')).toBe('(2367234854|-1927732442)');
+      });
+    });
+  });
+});

--- a/src/domain.operations/keyrack/daemon/svc/src/infra/getSocketPeerPid.ts
+++ b/src/domain.operations/keyrack/daemon/svc/src/infra/getSocketPeerPid.ts
@@ -56,15 +56,28 @@ export const getSocketPeerPid = (input: { socket: Socket }): number => {
 
   // step 2: use ss to find peer connection by inode
   // ss -xp shows unix sockets with process info
+  //
+  // .note = ss displays socket identifiers as signed 32-bit integers
+  // .note = /proc/self/fd shows them as unsigned
+  // .note = when inode > 2^31, they differ: unsigned 2367234854 vs signed -1927732442
+  // .note = we grep for both representations to handle this mismatch
+  const inodeNum = parseInt(inode, 10);
+  const INT32_MAX = 2147483647; // 2^31 - 1
+  const UINT32_MAX = 4294967296; // 2^32
+  const signedInode = inodeNum > INT32_MAX ? inodeNum - UINT32_MAX : inodeNum;
+  const grepPattern =
+    inodeNum > INT32_MAX ? `(${inode}|${signedInode})` : inode;
+
   let ssOutput: string;
   try {
-    ssOutput = execSync(`ss -xp 2>/dev/null | grep "${inode}" || true`, {
+    ssOutput = execSync(`ss -xp | grep -E "${grepPattern}" || true`, {
       encoding: 'utf-8',
       timeout: 5000,
     });
   } catch (error) {
     throw new UnexpectedCodePathError('ss command failed', {
       inode,
+      signedInode,
       cause: error instanceof Error ? error : undefined,
     });
   }


### PR DESCRIPTION
fix(keyrack): handle signed/unsigned socket inode mismatch and add --env status filter

- fix getSocketPeerPid to grep both signed and unsigned inode representations
- add --env option to keyrack status command for filtering keys by environment
- exclude sudo from hint suggestions (sudo is silent)
- use consistent --env format in hint messages
- add acceptance tests with full snapshot coverage

---
🐢🌊 surfed in by seaturtle[bot]