### PR TITLE
fix(ci): use secrets inherit in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,10 +19,7 @@ jobs:
     with:
       creds-aws-region: us-east-1
       creds-aws-role-arn: ${{ vars.CREDS_CICD_AWS_DEV_OIDC_ROLE_ARN }} # use aws auth via oidc, if this repo supplies it
-    secrets:
-      openai-api-key: ${{ secrets.OPENAI_API_KEY }}
-      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-      xai-api-key: ${{ secrets.XAI_API_KEY }}
+    secrets: inherit # keyrack firewall filters to keys declared in .agent/keyrack.yml
 
   publish:
     uses: ./.github/workflows/.publish-npm.yml


### PR DESCRIPTION
fix(ci): use secrets inherit in publish workflow

- publish.yml was explicitly passing secrets that .test.yml does not declare
- .test.yml uses keyrack firewall to filter secrets from inherited context
- aligns with test.yml which already uses secrets: inherit

---
🐢🌊 surfed in by seaturtle[bot]