### PR TITLE
fix(keyrack): check SSO cache expiration before trusting export-credentials

### DIFF
--- a/.behavior/v2026_06_14.fix-keyrack-sso-5/.bind/vlad.fix-keyrack-sso-5.flag
+++ b/.behavior/v2026_06_14.fix-keyrack-sso-5/.bind/vlad.fix-keyrack-sso-5.flag
@@ -1,0 +1,2 @@
+branch: vlad/fix-keyrack-sso-5
+bound_by: init.behavior skill

--- a/.behavior/v2026_06_14.fix-keyrack-sso-5/.route/.bind.vlad.fix-keyrack-sso-5.flag
+++ b/.behavior/v2026_06_14.fix-keyrack-sso-5/.route/.bind.vlad.fix-keyrack-sso-5.flag
@@ -1,0 +1,2 @@
+branch: vlad/fix-keyrack-sso-5
+bound_by: route.bind skill

--- a/.behavior/v2026_06_14.fix-keyrack-sso-5/.route/.gitignore
+++ b/.behavior/v2026_06_14.fix-keyrack-sso-5/.route/.gitignore
@@ -1,0 +1,5 @@
+# ignore all except passage.jsonl and .bind flags
+*
+!.gitignore
+!passage.jsonl
+!.bind.*

--- a/.behavior/v2026_06_14.fix-keyrack-sso-5/.route/passage.jsonl
+++ b/.behavior/v2026_06_14.fix-keyrack-sso-5/.route/passage.jsonl
@@ -1,0 +1,3 @@
+{"stone":"1.vision","status":"blocked","blocker":"review.self","reason":"review.self required: has-grounded-in-reality"}
+{"stone":"1.vision","status":"blocked","blocker":"review.self","reason":"review.self required: has-questioned-questions"}
+{"stone":"1.vision","status":"blocked","blocker":"approval","reason":"wait for human approval"}

--- a/.behavior/v2026_06_14.fix-keyrack-sso-5/0.wish.md
+++ b/.behavior/v2026_06_14.fix-keyrack-sso-5/0.wish.md
@@ -1,0 +1,76 @@
+wish =
+
+we gotta fix this once and for all. i thought we had several prs now which tried to address this? why does this come up again? seems like after N hours of an authed session, we start not detectnig when the session no longer works
+
+e.g., replicate via `aws sso logout`
+
+---
+
+                                
+                                                                                             
+❯ try to unlock again                                                                        
+                                                                                             
+● Bash(rhx keyrack unlock --owner ehmpath --env test)                                        
+  ⎿  🔓 keyrack unlock                                                                       
+        └─ ehmpathy.test.AWS_PROFILE                                                         
+           ├─ env: test    
+     … +3 lines (ctrl+o to expand)                                                           
+                                                                                             
+● Bash(rhx git.repo.test --what integration --scope setLambda)                               
+  ⎿  Error: Exit code 2                                                                      
+                                                                                             
+     🪨 run solid skill repo=ehmpathy/role=mechanic/skill=git.repo.test
+                                                                                             
+     🐢 lets ride...                                                                         
+                                  
+     🐚 git.repo.test --what integration --scope setLambda                                   
+        ├─ keyrack: unlocked ehmpath/test                   
+        ├─ status                                                                            
+        │  ├─ 💤 inflight (0s)                                                               
+     … +27 lines (ctrl+o to see all)
+                                                                                             
+● Keyrack unlocks the profile name, but the underlying AWS SSO token is expired. Need
+  interactive login:                                                                      
+                                                                                             
+  ! aws sso login --profile ehmpathy.demo
+
+
+  ---
+
+  then
+
+  
+declastruct-aws.vlad.fix-lambda-latest on vlad/fix-lambda-latest [$✘»!+?] is v1.5.0 via  v22.21.0 took 6m26s at 23:01:09 
+➜ rhx keyrack unlock --owner ehmpath --env test
+
+🔓 keyrack unlock
+   └─ ehmpathy.test.AWS_PROFILE
+      ├─ env: test
+      ├─ org: ehmpathy
+      ├─ vault: aws.config
+      └─ expires in: 540m
+
+
+declastruct-aws.vlad.fix-lambda-latest on vlad/fix-lambda-latest [$✘»!+?] is v1.5.0 via  v22.21.0 took 5s at 23:01:25 
+➜ aws sso login --profile ehmpathy.demo
+Attempting to open your default browser. If the browser does not open, open the following URL.
+If you are unable to open the URL on this device, run this command again with the '--use-device-code' option.
+
+https://oidc.us-east-1.amazonaws.com/authorize?response_type=code&client_id=Pt1hy_SsVzXv2Y2kSKA_dnVzLWVhc3QtMQ&redirect_uri=http%3A%2F%2F127.0.0.1%3A34527%2Foauth%2Fcallback&state=34d34a0a-0608-4479-991b-11ef8ee580c5&code_challenge_method=S256&scopes=sso%3Aaccount%3Aaccess&code_challenge=vA50Ihjg5HOcplc5tKqB7Ay8zG6j4HhRyPGi-xuTzWY
+
+Successfully logged into Start URL: https://d-906617ed8b.awsapps.com/start
+
+declastruct-aws.vlad.fix-lambda-latest on vlad/fix-lambda-latest [$✘»!+?] is v1.5.0 via  v22.21.0 took 17s at 23:01:49 
+➜ rhx keyrack unlock --owner ehmpath --env test
+
+🔓 keyrack unlock
+   └─ ehmpathy.test.AWS_PROFILE
+      ├─ env: test
+      ├─ org: ehmpathy
+      ├─ vault: aws.config
+      └─ expires in: 540m
+
+
+
+then, works again
+

--- a/.behavior/v2026_06_14.fix-keyrack-sso-5/1.vision.guard
+++ b/.behavior/v2026_06_14.fix-keyrack-sso-5/1.vision.guard
@@ -1,0 +1,89 @@
+# guard for vision stone
+#
+# requires human approval before stone can be marked as passed
+# because the self-review prompts require human feedback,
+# the process needs to halt here for human review
+
+judges:
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism approved? --stone $stone --route $route
+
+reviews:
+  self:
+    - slug: has-grounded-in-reality
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        did the junior ground the vision in reality, or make things up?
+
+        check the groundwork section:
+
+        for external references (APIs, services, docs):
+        - did they actually verify these exist?
+        - did they cite what they checked?
+        - or did they assume without sanity check?
+
+        for internal references (extant behavior, patterns, code):
+        - did they actually verify what that behavior is?
+        - did they verify extant contracts to conform to? (interfaces, types, signatures)
+        - did they verify extant vocab to reuse? (domain terms, name patterns)
+        - did they verify extant stdouts to match? (CLI output patterns, error formats)
+        - did they cite specific files/lines?
+        - or did they assume the code works a certain way without verification?
+
+        this is NOT about exhaustive research — just sanity checks.
+        the question is: is this vision coherent with reality, or built on assumptions?
+
+    - slug: has-questioned-requirements
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any requirements that should be questioned?
+
+        for each requirement, ask:
+        - who said this was needed? when? why?
+        - what evidence supports this requirement?
+        - what if we didn't do this — what would happen?
+        - is the scope too large, too small, or misdirected?
+        - could we achieve the goal in a simpler way?
+
+        challenge each requirement and justify why it belongs.
+
+    - slug: has-questioned-assumptions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any hidden assumptions the junior took as requirements?
+
+        for each assumption, ask:
+        - what do we assume here without evidence?
+        - what evidence supports this assumption?
+        - what if the opposite were true?
+        - did the wisher actually say this, or did we infer it?
+        - what exceptions or counterexamples exist?
+
+        surface all hidden assumptions and question each one.
+
+    - slug: has-questioned-questions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any open questions? triage them:
+
+        for each question, ask:
+        - can this be answered via logic now? if so, answer it now.
+        - can this be answered via extant docs or code now? if so, answer it now.
+        - should this be answered via external research later? if so, mark it for research.
+        - does only the wisher know the answer? if so, ask the wisher.
+
+        for each question, ensure it is clearly marked as either:
+        - [answered] — resolved now
+        - [research] — to be answered in the research phase
+        - [wisher] — requires wisher input
+
+        ensure they're enumerated within the vision under "open questions & assumptions"
+
+  peer: []

--- a/.behavior/v2026_06_14.fix-keyrack-sso-5/1.vision.stone
+++ b/.behavior/v2026_06_14.fix-keyrack-sso-5/1.vision.stone
@@ -1,0 +1,70 @@
+illustrate the vision implied in the wish .behavior/v2026_06_14.fix-keyrack-sso-5/0.wish.md
+
+emit into .behavior/v2026_06_14.fix-keyrack-sso-5/1.vision.yield.md
+
+---
+
+paint a picture of what the world looks like when this wish is fulfilled
+
+testdrive the contract we propose via realworld examples
+
+specifically,
+
+## the outcome world
+
+- what does a day-in-the-life look like with this in place?
+- what's the before/after contrast?
+- what's the "aha" moment where the value clicks?
+
+## user experience
+
+- what usecases do folks fulfill? what goals?
+- what contract inputs & outputs do they leverage?
+- what would it look like to leverage them?
+- what timelines do they go through?
+
+## mental model
+
+- how would users describe this to a friend?
+- what analogies or metaphors fit?
+- what terms would they use vs what terms would we use?
+
+## evaluation
+
+- how well does it solve the goals?
+- what are the pros? the cons?
+- what edgecases exist and how do our contracts keep users in a pit of success?
+
+## open questions & assumptions
+
+- what assumptions have we made?
+- what questions remain unanswered?
+- what must we validate with the wisher before we proceed?
+- what must we research externally?
+
+## groundwork
+
+sanity check the vision against reality. NOT exhaustive research — just enough to know the vision isn't built on false assumptions.
+
+### external research
+
+if the wish references external APIs, services, or docs:
+- did you verify they exist and work the way you assume?
+- cite what you checked (links, key constraints noted)
+- if none referenced, say "none — no external dependencies"
+
+### internal research
+
+if the wish references extant behavior, patterns, or code:
+- did you verify what that behavior actually is?
+- contracts: interfaces, types, signatures to conform to
+- vocab: domain terms, name patterns to reuse
+- stdouts: CLI output patterns, error formats to match
+- cite what you checked (file paths, line numbers)
+- if none referenced, say "none — no extant behavior extended"
+
+## what is awkward?
+
+- what feels off or forced?
+- where does the design fight the user's mental model?
+- what tradeoffs feel uncomfortable?

--- a/.behavior/v2026_06_14.fix-keyrack-sso-5/1.vision.yield.md
+++ b/.behavior/v2026_06_14.fix-keyrack-sso-5/1.vision.yield.md
@@ -1,0 +1,259 @@
+# vision: keyrack sso session validation
+
+## the outcome world
+
+### what does a day-in-the-life look like?
+
+**before:**
+```bash
+# morning: unlock keyrack, work for hours
+rhx keyrack unlock --owner ehmpath --env test
+# → "expires in: 540m" ✓
+
+# 6 hours later: tests start failing mysteriously
+rhx git.repo.test --what integration --mode apply
+# → Error: ExpiredTokenException
+
+# confused: keyrack says it's unlocked, but none of the calls work
+rhx keyrack status --owner ehmpath
+# → shows keys with time remaining
+
+# eventually figure out: aws sso session expired
+aws sso login --profile ehmpathy.demo
+# → browser auth
+# now it works again
+```
+
+**after:**
+```bash
+# morning: unlock keyrack
+rhx keyrack unlock --owner ehmpath --env test
+# → "expires in: 540m" ✓
+
+# 6 hours later: sso session expired, keyrack detects it
+rhx keyrack unlock --owner ehmpath --env test
+# → "⚠ sso session expired, re-authenticating..."
+# → browser auth opens automatically
+# → "expires in: 540m" ✓
+
+# or, if checking status:
+rhx keyrack status --owner ehmpath
+# → "ehmpathy.test.AWS_PROFILE: ⚠ sso expired, run unlock to refresh"
+```
+
+### the "aha" moment
+
+the value clicks when a mechanic runs `keyrack unlock` after an 8-hour session and instead of silently returning stale credentials that will fail mysteriously 10 minutes into a test run, keyrack says "your aws sso session expired, let me re-auth you" — and opens the browser automatically.
+
+no more confusion. no more "but keyrack says it's unlocked?!" debugging sessions.
+
+## user experience
+
+### usecases
+
+| usecase | goal | contract |
+|---------|------|----------|
+| unlock after long break | get fresh credentials | `keyrack unlock` detects stale sso, re-auths |
+| status check | see actual credential health | `keyrack status` shows sso expiration state |
+| debug failing tests | understand why creds don't work | clear error: "sso expired" not "locked" |
+
+### timeline
+
+1. **t=0h**: user runs `keyrack unlock`, sso session starts (8-12h depending on org settings)
+2. **t=6h**: user walks away for lunch
+3. **t=8h**: sso token expires (but daemon cache says "1h remaining")
+4. **t=9h**: user returns, runs `keyrack unlock`
+   - **current**: "expires in: 540m" (lie — sso is dead)
+   - **proposed**: "sso expired, re-authenticating..." → browser auth → "expires in: 540m" (truth)
+5. **t=9h+1m**: user runs integration tests → they work
+
+### contract inputs & outputs
+
+**unlock command:**
+```
+input: keyrack unlock --owner ehmpath --env test
+output (success): 🔓 unlocked, expires in: Xm
+output (expired): ⚠ sso session expired, re-authenticating... 🔓 unlocked
+output (error): ✗ sso login failed: <reason>
+```
+
+**status command:**
+```
+input: keyrack status --owner ehmpath
+output: shows actual sso token expiration, not just daemon cache TTL
+        flags keys where sso is expired but daemon cache remains
+```
+
+## mental model
+
+### how would users describe this to a friend?
+
+> "keyrack now checks if your aws sso is actually alive, not just if it remembers your profile name. if your sso session died while you were at lunch, keyrack catches it and re-auths you instead of pretending all is fine."
+
+### analogies
+
+| analogy | current behavior | proposed behavior |
+|---------|------------------|-------------------|
+| hotel key card | card copied, but hotel db says expired | checks with hotel before opening door |
+| cached auth token | returns cached token even if backend revoked it | validates token freshness against issuer |
+| car key fob | battery dead but you keep pressing unlock | tells you battery is dead before you're stuck |
+
+### terms
+
+| user term | internal term |
+|-----------|---------------|
+| "sso expired" | SSO access token in `~/.aws/sso/cache/` past `expiresAt` |
+| "keyrack stale" | daemon cache has grant but underlying sso is dead |
+| "refresh" | trigger `aws sso login` to get new token |
+
+## evaluation
+
+### how well does it solve the goals?
+
+| goal | solution | effectiveness |
+|------|----------|---------------|
+| detect expired sso | check `expiresAt` in sso cache files | 100% — direct source of truth |
+| auto-refresh on unlock | trigger sso login when expired | 100% — same ux as manual fix |
+| clear error messaging | "sso expired" vs "locked" | 100% — actionable feedback |
+
+### pros
+
+- **eliminates silent failures**: no more "keyrack says unlocked but tests fail"
+- **automatic recovery**: unlock command self-heals instead of lying
+- **transparent**: user sees exactly what's happening
+- **no extra commands**: extant workflow just gets smarter
+
+### cons
+
+- **slightly more validation time**: reading sso cache adds ~10ms to unlock
+- **requires sso cache access**: if cache files are corrupted, falls back to export-credentials
+
+### edge cases and pit of success
+
+| edge case | behavior |
+|-----------|----------|
+| sso cache file absent | fallback to `export-credentials` validation |
+| sso cache file corrupted | fallback to `export-credentials` validation |
+| multiple sso domains | match by `ssoStartUrl` from profile config |
+| sso token expires mid-test | tests fail (expected — we can't interrupt running tests) |
+| user runs `aws sso logout` | next `keyrack unlock` detects + re-auths |
+
+## open questions & assumptions
+
+### assumptions
+
+1. **SSO cache is authoritative**: `~/.aws/sso/cache/*.json` files contain the true expiration time
+2. **expiresAt is accurate**: aws cli writes correct expiration timestamps
+3. **one sso session per domain**: matching by `ssoStartUrl` is sufficient
+4. **export-credentials returns stale**: this is the root cause (not daemon cache alone)
+
+### questions [answered] — resolved via research
+
+1. **Q: does export-credentials return stale credentials?**
+   - **answer: YES** — confirmed via aws-cli GitHub issues and AWS documentation
+   - aws-cli GitHub discussion #9237 documents: "There is an edge case where SSO credentials have expired but the cached STS credential for CLI is still valid, so that aws-cli still appears to work"
+   - two independent caches with different TTLs:
+     - `~/.aws/sso/cache/*.json` — SSO access tokens (8h validity)
+     - `~/.aws/cli/cache/*.json` — STS role credentials (1h validity, auto-refresh)
+   - when SSO token expires, cached STS credentials can remain valid for up to 1 hour
+   - `export-credentials` returns cached STS without re-validation of SSO token
+   - **citations:**
+     - [aws-cli discussion #9237](https://github.com/aws/aws-cli/discussions/9237)
+     - [aws-cli issue #6948](https://github.com/aws/aws-cli/issues/6948)
+     - [AWS docs: IAM Identity Center credential provider](https://docs.aws.amazon.com/sdkref/latest/guide/feature-sso-credentials.html)
+
+### questions [answered] — resolved via analysis
+
+1. **Q: why did prior fixes fail?**
+   - prior fix (v2026_05_09) assumed export-credentials validates SSO
+   - if export-credentials returns cached STS without SSO check, the assumption was wrong
+   - this explains why the problem persists despite prior fix
+
+2. **Q: what's the typical SSO token TTL?**
+   - varies by org settings (8-12h typical)
+   - the fix reads actual `expiresAt` from cache, so variance is handled automatically
+   - no need to hardcode or research typical values
+
+### external research: complete
+
+**root cause confirmed via aws-cli GitHub:**
+- [aws-cli discussion #9237](https://github.com/aws/aws-cli/discussions/9237) — documents the exact edge case: "SSO credentials have expired but the cached STS credential for CLI is still valid"
+- [aws-cli issue #6948](https://github.com/aws/aws-cli/issues/6948) — requests `aws sso login` respect credential expiration
+- [aws-cli issue #10258](https://github.com/aws/aws-cli/issues/10258) — requests opt-in SSO token revoke for export-credentials
+
+**cache structure confirmed via AWS docs:**
+- [IAM Identity Center credential provider](https://docs.aws.amazon.com/sdkref/latest/guide/feature-sso-credentials.html) — documents `~/.aws/sso/cache` structure
+- [IAM Identity Center concepts](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso-concepts.html) — documents 8h access token validity
+- sso cache format: json with `accessToken`, `expiresAt`, `startUrl`
+- sts cache: `~/.aws/cli/cache/*.json` with `AccessKeyId`, `SecretAccessKey`, `SessionToken`
+
+### internal research: complete
+
+**contracts verified:**
+- `vaultAdapterAwsConfig.isUnlocked()` — calls `validateSsoSession()`
+- `validateSsoSession()` — relies on `export-credentials` (the problem)
+- `previewAwsSsoCacheForDomain()` — already reads sso cache files
+- `getAllAwsSsoCacheEntries()` — parses `~/.aws/sso/cache/*.json`
+
+**vocab confirmed:**
+- sso cache: `~/.aws/sso/cache/*.json`
+- sts cache: `~/.aws/cli/cache/*.json`
+- profile config: `~/.aws/config` with `sso_start_url`, `sso_account_id`, etc.
+
+**extant code to reuse:**
+- `previewAwsSsoCacheForDomain()` — already checks `expiresAt` (line 31)
+- `getAwsSsoProfileConfig()` — gets `ssoStartUrl` for a profile
+- `clearAwsSsoCacheForDomain()` — clears cache when needed
+
+## groundwork
+
+### external research
+
+**root cause validated via aws-cli GitHub issues:**
+- the exact edge case is documented in [aws-cli discussion #9237](https://github.com/aws/aws-cli/discussions/9237)
+- quote: "There is an edge case where SSO credentials have expired but the cached STS credential for CLI is still valid, so that aws-cli still appears to work, but no other tool works"
+- this confirms our hypothesis: `export-credentials` returns cached STS without SSO validation
+
+### internal research
+
+**validated assumptions:**
+1. `validateSsoSession()` at `vaultAdapterAwsConfig.ts:75-126` — relies solely on `export-credentials`
+2. `previewAwsSsoCacheForDomain()` at `previewAwsSsoCacheForDomain.ts:7-40` — already reads sso cache with `expiresAt`
+3. `unlock()` at `vaultAdapterAwsConfig.ts:205-291` — only triggers login when `validateSsoSession()` returns invalid
+
+**the gap:**
+- `validateSsoSession()` uses `export-credentials` which can return cached STS creds
+- STS creds can be valid hours after SSO token expires
+- no direct check of SSO token expiration
+
+**the fix location:**
+- `validateSsoSession()` should also check SSO cache `expiresAt` before trusting `export-credentials`
+- or: add new function `isSsoSessionExpired()` that checks cache directly
+
+## what is awkward?
+
+### forced tradeoffs
+
+1. **two caches**: aws has both SSO cache and STS cache; we must check both
+2. **cache file parsing**: reading json files is fragile but necessary
+3. **domain matching**: must match profile → sso start url → cache file
+
+### where the design fights the user's mental model
+
+users think "keyrack unlock = my aws creds work" but reality is:
+- keyrack only validates what aws cli tells it
+- aws cli can lie about credential freshness
+- the fix: keyrack becomes smarter than aws cli's export-credentials
+
+### uncomfortable tradeoffs
+
+1. **adding validation time**: 10ms per unlock to read sso cache
+   - acceptable: unlock is infrequent, reliability matters more
+
+2. **duplicate validation**: both sso cache AND export-credentials
+   - necessary: export-credentials alone is insufficient
+   - can short-circuit: if sso cache shows expired, skip export-credentials
+
+3. **still can't prevent mid-test expiration**: if sso expires during a long test run, tests will fail
+   - acceptable: at least the NEXT unlock will detect and fix it
+   - enhancement (future): warn when TTL is shorter than expected work duration

--- a/.behavior/v2026_06_14.fix-keyrack-sso-5/5.1.execution.from_vision.guard
+++ b/.behavior/v2026_06_14.fix-keyrack-sso-5/5.1.execution.from_vision.guard
@@ -1,0 +1,180 @@
+# guard for execution stone (from vision - nano size)
+# includes standardized self-review frame
+
+artifacts:
+  # track execution progress
+  - "$route/5.1.execution.from_vision.yield.md"
+  # track actual implementation in src/
+  - "src/**/*"
+
+reviews:
+  self:
+    # 1. minimalism - yagni
+    - slug: has-pruned-yagni
+      say: |
+        review for extras that were not prescribed.
+
+        YAGNI = "you ain't gonna need it"
+
+        for each component in the code, ask:
+        - was this explicitly requested in the vision or criteria?
+        - is this the minimum viable way to satisfy the requirement?
+        - did we add abstraction "for future flexibility"?
+        - did we add features "while we're here"?
+        - did we optimize before we knew it was needed?
+
+        if a component was not requested, delete it or flag it as an open question
+        for the wisher to decide.
+
+    # 2. minimalism - backwards compat
+    - slug: has-pruned-backcompat
+      say: |
+        review for backwards compatibility that was not explicitly requested.
+
+        for each backwards-compat concern in the code, ask:
+        - did the wisher explicitly say to maintain this compatibility?
+        - is there evidence this backwards compat is needed?
+        - or did we assume it "to be safe"?
+
+        if backwards compat was not explicitly requested:
+        1. flag it as an open question for the wisher
+        2. eliminate it if not confirmed as required
+        3. make the open question very clearly reported
+
+    # 3. consistency - mechanisms
+    - slug: has-consistent-mechanisms
+      say: |
+        review for new mechanisms that duplicate extant functionality.
+
+        unless the ask was to refactor, be consistent with extant mechanisms.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). look for extant utilities and patterns.
+
+        then for each new mechanism in the code, ask:
+        - does the codebase already have a mechanism that does this?
+        - do we duplicate extant utilities or patterns?
+        - could we reuse an extant component instead of a new one?
+
+        if a new mechanism duplicates extant functionality:
+        1. replace with the extant mechanism
+        2. or flag as an open question if unsure
+
+    # 4. consistency - conventions
+    - slug: has-consistent-conventions
+      say: |
+        review for divergence from extant names and patterns.
+
+        unless the ask was to refactor, be consistent with extant conventions.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). identify extant name conventions and patterns.
+
+        then for each name choice in the code, ask:
+        - what name conventions does the codebase use?
+        - do we use a different namespace, prefix, or suffix pattern?
+        - do we introduce new terms when extant terms exist?
+        - does our structure match extant patterns?
+
+        if we diverge from extant conventions:
+        1. align with the extant convention
+        2. or flag as an open question if the extant convention seems wrong
+
+    # 5. review against behavior declaration - coverage
+    - slug: behavior-declaration-coverage
+      say: |
+        review for coverage of the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have omitted
+        requirements or left features unimplemented.
+
+        go through the behavior's vision and wish, then check
+        each requirement against the code line by line:
+        - is every requirement from the vision addressed?
+        - did the junior skip or forget any part of the spec?
+
+        fix all gaps before you continue.
+
+    # 6. review against behavior declaration - adherance
+    - slug: behavior-declaration-adherance
+      say: |
+        review for adherance to the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have drifted
+        from the spec or implemented items incorrectly.
+
+        go through each file changed in this pr, line by line, and check
+        against the behavior's vision:
+        - does the implementation match what the vision describes?
+        - did the junior misinterpret or deviate from the spec?
+
+        fix all gaps before you continue.
+
+    # 7. review against role standards - adherance
+    - slug: role-standards-adherance
+      say: |
+        review for adherance to mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have introduced
+        bad practices or violated patterns that we require.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this code
+        - confirm you have not missed any rule categories
+
+        then go through each file changed in this pr, line by line, and check:
+        - does the code follow mechanic standards correctly?
+        - are there violations of required patterns?
+        - did the junior introduce anti-patterns, bad practices, or deviations from our conventions?
+
+        fix all gaps before you continue.
+
+    # 8. review against role standards - coverage
+    - slug: role-standards-coverage
+      say: |
+        review for coverage of mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have forgotten
+        best practices or omitted patterns that should be present.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this code
+        - confirm you have not missed any rule categories
+
+        then go through each file changed in this pr, line by line, and check:
+        - are all relevant mechanic standards applied?
+        - are there patterns that should be present but are absent?
+        - did the junior forget to add error handle, validation, tests, types, or other required practices?
+
+        fix all gaps before you continue.
+
+  peer:
+    # slug = mech-failhides
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.mech-failhides.md'
+
+    # slug = mech-decode-friction
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.{forbid.decode-friction-in-orchestrators,require.orchestrators-as-narrative}.md' --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/rule.{forbid.inline-decode-friction,require.named-transforms}.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/{define.domain-operation-grains,philosophy.transform-orchestrator-separation.[philosophy]}.md' --diffs since-main --paths-with '**/*.ts' --paths-without '**/*.test.ts' --join intersect --output '$route/.reviews/$stone.peer-review.mech-decode-friction.md'
+
+    # --- architect reviews ---
+    # lineage: $rhachet enroll claude --roles behaver,architect,mechanic -p "review the current implementation for architectural defects and omissions; opports to decompose for recompose, prevent scope leaks, and eliminate maintenance and behavior hazards structurally. emit BLOCKERS and NITPICKS."
+    # slug = arch-opport-decomposition
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.arch-opport-decomposition.md'
+    # slug = arch-smell-scopeleaks
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.scope-leaks.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.arch-smell-scopeleaks.md'
+    # slug = arch-hazards-maintenance
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.require.solve-at-cause.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.typedefs/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.comments/*.md.min' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.arch-hazards-maintenance.md'
+    # slug = arch-hazards-behavior
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.arch-hazards-behavior.md'
+
+    # lineage: $rhachet enroll claude --roles behaver,architect,mechanic -p "review the current implementation for omissions or divergences from the wished and envisioned behavioral intent. in particular flag any ergonomic friction that is unaddressed or friction hazards that are not clearly covered with acceptance tests and snaps. emit BLOCKERS and NITPICKS."
+    # slug = behavior-intent-coverage
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.require.behavior-intent-coverage.md' --refs '$route/0.wish.md' --refs '$route/1.vision.yield.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.criteria/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.behavior-intent-coverage.md'
+    # slug = ergo-friction-hazards
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.friction-hazards.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.ergo-friction-hazards.md'
+
+judges:
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 3

--- a/.behavior/v2026_06_14.fix-keyrack-sso-5/5.1.execution.from_vision.stone
+++ b/.behavior/v2026_06_14.fix-keyrack-sso-5/5.1.execution.from_vision.stone
@@ -1,0 +1,15 @@
+bootup your mechanic's role via `./node_modules/.bin/rhachet roles boot --repo ehmpathy --role mechanic`
+
+then, execute the vision directly
+- .behavior/v2026_06_14.fix-keyrack-sso-5/1.vision.md
+
+ref:
+- .behavior/v2026_06_14.fix-keyrack-sso-5/0.wish.md
+
+
+---
+
+track your progress
+
+emit todos and check them off into
+- .behavior/v2026_06_14.fix-keyrack-sso-5/5.1.execution.from_vision.yield.md

--- a/.behavior/v2026_06_14.fix-keyrack-sso-5/5.3.verification.guard
+++ b/.behavior/v2026_06_14.fix-keyrack-sso-5/5.3.verification.guard
@@ -1,0 +1,258 @@
+artifacts:
+  # track verification progress
+  - "$route/5.3.verification.yield.md"
+  # track actual implementation in src/
+  - "src/**/*"
+
+reviews:
+  self:
+    - slug: has-behavior-coverage
+      say: |
+        double-check: does the verification checklist show every behavior from wish/vision has a test?
+
+        - is every behavior in 0.wish.md covered?
+        - is every behavior in 1.vision.md covered?
+        - can you point to each test file in the checklist?
+
+        **if any behavior lacks a test, write the test NOW.** do not pass this gate with gaps.
+
+    - slug: has-zero-test-skips
+      say: |
+        double-check: did you verify zero skips — and REMOVE any you found?
+
+        - no .skip() or .only() found?
+        - no silent credential bypasses?
+        - no prior failures carried forward?
+
+        **if you found skips, did you remove them and make those tests pass?**
+
+        this is buttonup. skips are gaps. gaps get fixed, not noted.
+
+    - slug: has-all-tests-passed
+      say: |
+        double-check: did all tests pass? prove it.
+
+        **zero unproven claims.** you must cite the exact command and output.
+
+        for each test suite:
+        - what command did you run?
+        - what was the exit code?
+        - how many tests passed?
+
+        example proof:
+        ```
+        $ npm run test:unit
+        > exit 0
+        > 47 tests passed
+        ```
+
+        if you cannot cite the command and output, you did not prove it.
+
+        zero tolerance for extant failures:
+        - "it was already broken" is not an excuse — fix it
+        - "it's unrelated to my changes" is not an excuse — fix it
+        - flaky tests must be stabilized, not tolerated
+        - every failure is your responsibility now
+
+        zero tolerance for fake tests:
+        - tests that always pass are fraud
+        - tests that mock the system under test prove nothingness
+        - tests must verify real behavior
+
+        zero tolerance for credential excuses:
+        - "i don't have creds" means get them or mock them
+        - silent bypasses are forbidden
+        - if creds block tests, that is a BLOCKER — not a deferral
+
+    - slug: has-preserved-test-intentions
+      say: |
+        double-check: did you preserve test intentions?
+
+        for every test you touched:
+        - what did this test verify before?
+        - does it still verify the same behavior after?
+        - did you change what the test asserts, or fix why it failed?
+
+        forbidden:
+        - weaken assertions to make tests pass
+        - remove test cases that "no longer apply"
+        - change expected values to match broken output
+        - delete tests that fail instead of fix code
+
+        the test knew a truth. if it failed, either:
+        - the code is wrong — fix the code
+        - the test has a bug — fix the bug, keep the intention
+        - requirements changed — document why, get approval
+
+        to "fix tests" via changed intent is not a fix — it is at worst
+        malicious deception, at best reckless negligence. unacceptable.
+
+    - slug: has-journey-tests-from-repros
+      say: |
+        double-check: did you implement each journey sketched in repros?
+
+        look back at the repros artifact:
+        - .behavior/v2026_06_14.fix-keyrack-sso-5/3.2.distill.repros.experience.*.md
+
+        for each journey test sketch in repros:
+        - is there a test file for it?
+        - does the test follow the BDD given/when/then structure?
+        - does each `when([tN])` step exist?
+
+        **if any journey was planned but not implemented, go back and add it NOW.**
+
+        this is buttonup. absent journey tests = incomplete implementation.
+        test coverage proves prod coverage. no test = no proof = not done.
+
+    - slug: has-contract-output-variants-snapped
+      say: |
+        double-check: does each public contract have EXHAUSTIVE snapshots?
+
+        **zero gaps in caller experience.** every contract must snap every output variant.
+
+        for each new or modified public contract:
+
+        | contract type | what to snap | required variants |
+        |---------------|--------------|-------------------|
+        | cli command | stdout + stderr | success, error, --help, edge cases |
+        | api endpoint | response body | 2xx, 4xx, 5xx, edge cases |
+        | sdk method | return value | success, error, edge cases |
+
+        checklist per contract:
+        - [ ] positive path (success) is snapped
+        - [ ] negative path (error) is snapped
+        - [ ] help/usage is snapped (for cli)
+        - [ ] edge cases are snapped (empty, invalid, boundary)
+        - [ ] snapshot shows actual output, not placeholder
+
+        why this matters:
+        - snapshots enable vibecheck in prs — reviewers see actual output without execute
+        - snapshots detect drift over time — output changes surface in diffs
+        - absent variants mean blind spots in review
+        - exhaustive coverage proves the contract works for all callers
+
+        **zero leniency.** if a contract lacks any variant, add the test case NOW.
+
+        if you find yourself about to say "this variant isn't worth a snapshot" — stop.
+        that is the variant that will break in prod. snap it.
+
+        this is buttonup. absent snapshots = absent proof. add them or fail this gate.
+
+    - slug: has-snap-changes-rationalized
+      say: |
+        double-check: is every `.snap` file change intentional and justified?
+
+        for each `.snap` file in git diff:
+        1. what changed? (added, modified, deleted)
+        2. was this change intended or accidental?
+        3. if intended: what is the rationale?
+        4. if accidental: revert it or explain why the new output is an improvement
+
+        common regressions caught here:
+        - output format degraded (lost alignment, lost structure)
+        - error messages became less helpful
+        - timestamps or ids leaked into snapshots (flaky)
+        - extra output added unintentionally
+
+        forbidden:
+        - "updated snapshots" without per-file rationale
+        - bulk snapshot updates without review
+        - regressions accepted without justification
+
+        every snap change tells a story. make sure the story is intentional.
+
+    - slug: has-critical-paths-frictionless
+      say: |
+        double-check: are the critical paths frictionless in practice?
+
+        look back at the repros artifact for critical paths:
+        - .behavior/v2026_06_14.fix-keyrack-sso-5/3.2.distill.repros.experience.*.md
+
+        for each critical path:
+        - run through it manually — is it smooth?
+        - are there unexpected errors?
+        - does it feel effortless to the user?
+
+        critical paths must "just work." if there's friction, fix it now.
+
+    - slug: has-ergonomics-validated
+      say: |
+        double-check: does the actual input/output match what felt right at repros?
+
+        compare the implemented input/output to what was sketched in repros:
+        - does the actual input match the planned input?
+        - does the actual output match the planned output?
+        - did the design change between repros and implementation?
+
+        if the ergonomics drifted, either:
+        - update repros to reflect the better design, or
+        - fix the implementation to match the planned ergonomics
+
+    - slug: has-play-test-convention
+      say: |
+        double-check: are journey test files named correctly?
+
+        journey tests should use `.play.test.ts` suffix:
+        - `feature.play.test.ts` — journey test
+        - `feature.play.integration.test.ts` — if repo requires integration runner
+        - `feature.play.acceptance.test.ts` — if repo requires acceptance runner
+
+        verify:
+        - are journey tests in the right location?
+        - do they have the `.play.` suffix?
+        - if not supported, is the fallback convention used?
+
+    - slug: has-fixed-all-gaps
+      say: |
+        final buttonup check: did you FIX every gap you found, or just detect it?
+
+        **this is the buttonup phase. detection is not enough — you must fix.**
+
+        look back at all the reviews above. for every gap you identified:
+        - absent test coverage → did you WRITE the test?
+        - absent prod coverage → did you IMPLEMENT the behavior?
+        - failed test → did you FIX the code or test?
+        - skipped test → did you REMOVE the skip and make it pass?
+
+        **zero omissions.** if any review above surfaced a gap, that gap must be fixed before you pass this gate.
+
+        ask yourself:
+        - did i just note the gap, or did i actually fix it?
+        - is there any item marked "todo" or "later"? (forbidden)
+        - is there any coverage marked incomplete? (forbidden)
+
+        **if you detected it, you fixed it.** prove it with citations.
+
+        this is the final self-review. you are about to hand off to peer review.
+        prove that all items above were addressed — not deferred.
+
+  peer:
+    # slug = ergo-contract-snapshots
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.ergo-contract-snapshots.md'
+
+    # slug = mech-external-contracts
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.external-contract-integration-tests.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.unit/rule.forbid.remote-boundaries.md' --diffs since-main --paths-with '**/*.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.mech-external-contracts.md'
+
+    # --- ergonomist reviews ---
+    # lineage: $rhachet enroll claude --model sonnet --roles behaver,ergonomist,mechanic -p "review the diff for snapshot coverage on contract endpoints and acceptance test user journey coverage. emit BLOCKERS and NITPICKS."
+    # slug = ergo-acceptance-journey-coverage
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.require.acceptance-journey-coverage.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.ergo-acceptance-journey-coverage.md'
+
+    # lineage: $rhachet enroll claude --model sonnet --roles behaver,ergonomist,mechanic -p "review the diff for experiential and visual blemishes in snapshotted acceptance test journeys. emit BLOCKERS and NITPICKS."
+    # slug = ergo-snapshot-visual-blemishes
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.forbid.snapshot-visual-blemishes.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --diffs since-main --paths-with '**/*.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.ergo-snapshot-visual-blemishes.md'
+
+    # slug = mech-given-when-then
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/rule.require.given-when-then.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/criteria.given_when_then.[seed].v3.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/lessons.howto/*.md.min' --diffs since-main --paths-with '**/*.test.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.mech-given-when-then.md'
+
+    # --- test intent reviews ---
+    # lineage: $rhachet enroll claude --model sonnet --roles behaver,architect,mechanic -p "review the current implementation for test intent violation diffs. if any of the diffs related to tests loosened assertions or changed the criteria, this is a blocker. tests were added for a reason. we have to maintain the behavior they locked in. emit BLOCKERS and NITPICKS."
+    # slug = mech-test-intent
+    - $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.forbid.test-intent-violations.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/work.flow/refactor/rule.require.review-test-changes.md.min' --diffs since-main --paths-with '**/*.test.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.mech-test-intent.md'
+
+    # verify test scope purity (grain, boundaries, mocks, blackbox)
+    - $rhachet run --repo bhrain --skill review --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/rule.require.test-coverage-by-grain.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.unit/rule.forbid.unit.remote-boundaries.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.integration/rule.forbid.integration.mocks.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.acceptance/rule.forbid.acceptance.mocks.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.acceptance/rule.require.acceptance.blackbox.md' --diffs since-main --paths-with '{src,blackbox}/**/*.test.ts' --join intersect --output '$route/.reviews/$stone.peer-review.test-scope-purity.md' --mode hard
+
+judges:
+  # enforce peer reviews pass with zero blockers
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 0

--- a/.behavior/v2026_06_14.fix-keyrack-sso-5/5.3.verification.stone
+++ b/.behavior/v2026_06_14.fix-keyrack-sso-5/5.3.verification.stone
@@ -1,0 +1,304 @@
+prove the deliverable works via test verification — fix all gaps
+
+---
+
+## .what
+
+this is the verification gate — the **buttonup phase**.
+
+you cannot pass execution without proof that all tests pass. more importantly: **test coverage enforces prod coverage**. if tests are absent, prod is incomplete. if prod is incomplete, fix it.
+
+## .the buttonup mandate: zero omissions
+
+**this is not a detection phase. this is a completion phase.**
+
+when you find a gap, you do not note it and move on. you **fix it**.
+
+| gap type | action |
+|----------|--------|
+| absent test coverage | write the test NOW |
+| absent prod coverage | implement the behavior NOW |
+| failed test | fix the code or fix the test NOW |
+| skipped test | remove the skip and make it pass NOW |
+
+**if you detect it, you fix it. no exceptions.**
+
+## .strictness: zero tolerance, zero exceptions
+
+**this gate enforces absolute standards. there is no leniency.**
+
+| constraint | definition |
+|------------|------------|
+| zero deferrals | you cannot defer any test to later. all tests pass now or you fail. |
+| zero fake tests | tests must verify real behavior. assertions that always pass are fraud. |
+| zero unproven claims | every claim of "test passes" must cite the exact command run and output. |
+| zero credential excuses | "i don't have creds" is not an excuse. get them, mock them, or fail. |
+| zero skips | .skip() and .only() are forbidden. silent bypasses are forbidden. |
+| zero exceptions | there are no special cases. the rules apply to all. |
+| zero omissions | if you find a gap in coverage, you fix it — test or prod. |
+
+**if a blocker prevents tests from run, that is a BLOCKER. full stop.**
+
+you do not proceed. you do not defer. you fix it or you fail the gate.
+
+## .why
+
+**why does this gate exist?**
+
+your crew is about to review a pr you wrote. they need proof it works — not words, proof. tests are that proof.
+
+**test coverage drives prod coverage.** if a behavior lacks a test, that behavior is unproven. unproven behaviors are incomplete deliverables. the test proves the implementation exists and works.
+
+without this gate:
+- tests might fail and nobody notices
+- tests might be skipped and nobody notices
+- behaviors might lack coverage and nobody notices
+- broken code ships to peers
+- incomplete implementations slip through
+
+with this gate:
+- every test passes or you fix it
+- every behavior has coverage or you add it
+- every skip is removed or justified
+- proven code ships to peers
+- **gaps get fixed, not deferred**
+
+**the cardinal rules**:
+1. never leave behavior without true, dependable test coverage
+2. never offload work onto your crew unless there is truly, fundamentally no other option
+3. never claim a test passes without cite of the exact command and output
+
+you fix it yourself. you exhaust every option: debug, research, try alternatives. only when you hit a wall that is physically impossible to climb alone — credentials only the foreman possesses, access only they can grant — only then may you ask for help.
+
+## .how
+
+reference the below for full context
+- .behavior/v2026_06_14.fix-keyrack-sso-5/0.wish.md
+- .behavior/v2026_06_14.fix-keyrack-sso-5/1.vision.md
+- .behavior/v2026_06_14.fix-keyrack-sso-5/2.1.criteria.blackbox.md (if declared)
+- .behavior/v2026_06_14.fix-keyrack-sso-5/3.2.distill.repros.experience.*.md (if declared) ← **repros artifact**
+
+---
+
+### step 1: emit verification checklist
+
+emit to
+- .behavior/v2026_06_14.fix-keyrack-sso-5/5.3.verification.yield.md
+
+this is your roadmap. emit it first, then work through it step by step.
+
+**checklist structure:**
+
+```
+## verification checklist
+
+### behavior coverage (with reference to repros)
+
+for each journey sketched in repros, verify it was implemented with snapshots.
+
+| journey (from repros) | test file | snapshots? | critical path? | ergonomics ok? | status |
+|-----------------------|-----------|------------|----------------|----------------|--------|
+| {journey 1}           | {path}    | ✓ / ✗      | ✓ frictionless / needs work | ✓ natural / needs work | ⏳ |
+| {journey 2}           | {path}    | ✓ / ✗      | ✓ frictionless / needs work | ✓ natural / needs work | ⏳ |
+...
+
+### zero skips verified
+- [ ] no .skip() or .only() found
+- [ ] no silent credential bypasses
+- [ ] no prior failures carried forward
+
+### snapshot coverage for contract outputs
+
+each public contract needs dedicated snapshots that demonstrate its stdout for:
+- **vibechecks in prs** — reviewers see actual output without executing code
+- **drift detection** — changes to output surface in diffs over time
+
+| contract | output variants | snapshot file | status |
+|----------|-----------------|---------------|--------|
+| {command 1} | success, error, help | {path.snap} | ⏳ |
+| {command 2} | success, error, help | {path.snap} | ⏳ |
+...
+
+checklist:
+- [ ] every new cli command has `.snap` snapshots for stdout/stderr
+- [ ] every new app screen has `.snap` snapshots for screenshots
+- [ ] every new sdk method has `.snap` snapshots for responses
+- [ ] each output variant is exercised (success, error, edge cases)
+- [ ] snapshots demonstrate actual output, not just "it ran"
+
+### snapshot change rationalization
+
+for each `.snap` file changed, rationalize whether the change was intended or accidental:
+
+| snap file | change type | intended? | rationale |
+|-----------|-------------|-----------|-----------|
+| {path.snap} | added / modified / deleted | yes / no | {why this change is correct} |
+...
+
+checklist:
+- [ ] every `.snap` change has been reviewed
+- [ ] intended changes have clear rationale
+- [ ] accidental changes have been reverted or justified as improvements
+
+### tests executed — with proof
+
+**every test run must be proven with exact command and output.**
+
+| test suite | command run | result | proof (exit code + summary) |
+|------------|-------------|--------|----------------------------|
+| types | `npm run test:types` | ✓ / ✗ | exit 0, no errors |
+| lint | `npm run test:lint` | ✓ / ✗ | exit 0, no errors |
+| format | `npm run test:format` | ✓ / ✗ | exit 0, no errors |
+| unit | `npm run test:unit` | ✓ / ✗ | exit 0, N tests passed |
+| integration | `npm run test:integration` | ✓ / ✗ | exit 0, N tests passed |
+| acceptance | `npm run test:acceptance` | ✓ / ✗ | exit 0, N tests passed |
+
+checklist:
+- [ ] every test command was run (not "i think it passed")
+- [ ] every test command output was observed (not assumed)
+- [ ] the exact exit code was verified (0 = pass, non-zero = fail)
+- [ ] no tests were skipped, mocked, or faked
+
+**zero unproven claims.** if you claim a test passes, cite the command and output.
+
+### contract output snapshot exhaustiveness
+
+**every user-faced contract must have exhaustive snapshot coverage.**
+
+| contract type | contract | positive path snapped? | negative path snapped? | edge cases snapped? |
+|---------------|----------|------------------------|------------------------|---------------------|
+| cli | {command} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+| api | {endpoint} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+| sdk | {method} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+
+checklist:
+- [ ] every cli command has stdout/stderr snapshots for success, error, and help
+- [ ] every api endpoint has response snapshots for success and error codes
+- [ ] every sdk method has return value snapshots for success and error
+- [ ] every contract has edge case snapshots (empty input, invalid input, boundary)
+
+**zero gaps in caller experience.** the reviewer must see exactly what callers see.
+
+### blockers
+- none (or list handoff references)
+```
+
+update the checklist as you complete each step below.
+
+---
+
+### step 2: verify AND FIX behavior coverage
+
+walk through wish and vision:
+- every behavior promised must have an acceptance test
+- for each behavior, you can point to the test file
+- no behavior left untested
+
+**why?** your crew trusts the test suite. if a behavior isn't tested, it isn't proven. untested behaviors are unverified promises.
+
+**test coverage enforces prod coverage.** if a test is absent, either:
+1. the behavior was not implemented → IMPLEMENT IT NOW
+2. the behavior was implemented without a test → WRITE THE TEST NOW
+
+if a behavior lacks a test, **write one NOW**. do not move on with gaps. update your checklist when done.
+
+---
+
+### step 3: verify AND FIX zero skips
+
+scan for forbidden patterns:
+- `.skip()` or `.only()` in test files
+- `if (!credentials) return` or similar silent bypasses
+- prior failures carried forward (known-broken tests)
+
+**why?** failures are better than skips. skips hide problems. failures expose them. a skipped test is a lie — it pretends coverage exists when it doesn't.
+
+**this is buttonup.** if you find skips:
+1. REMOVE the skip
+2. MAKE the test pass (fix the code or fix the test)
+3. update your checklist
+
+do not note skips and move on. fix them. all tests must run.
+
+---
+
+### step 4: run all tests AND FIX all failures
+
+run each test suite and **cite the exact command and output**.
+
+```bash
+npm run test:types      # cite exit code
+npm run test:lint       # cite exit code
+npm run test:format     # cite exit code
+npm run test:unit       # cite exit code + test count
+npm run test:integration # cite exit code + test count
+npm run test:acceptance  # cite exit code + test count
+```
+
+all must pass — no exceptions. no deferrals. no "i'll fix it later."
+
+**this is buttonup.** if tests fail, fix them. that is the job.
+
+failures indicate one of:
+1. prod code is broken → FIX THE PROD CODE
+2. test has a bug → FIX THE TEST BUG (preserve intention)
+3. coverage gap exists → FILL THE GAP
+
+**consider all failures as defects from this pr.** there are no "prior failures."
+
+if a test was broken before you started — fix it. if a test is flaky — fix it. if a test fails for reasons unrelated to your changes — fix it anyway. you do not get to say "that was already broken." you are here now. you fix it.
+
+**take initiative. take ownership.**
+
+**preserve test intentions.** when you fix a test, you fix why it failed — not what it tests. to change what a test verifies is not a fix. it is at worst malicious deception, at best reckless negligence. the test knew a truth. if it fails, either the code is wrong or the test has a bug. fix the cause, not the assertion.
+
+**zero fake tests.** a test that always passes is fraud. a test that skips is a lie. a test that mocks the system under test proves nothingness. tests must verify real behavior against real code.
+
+**escalation path:**
+1. debug the failure — read the error, understand the cause
+2. research — search for similar issues, read docs
+3. try alternatives — different approach, different tool
+4. ask for help — other resources, other clones
+5. deeper research — exhaust every option
+6. only if insurmountable — emit handoff (see step 5)
+
+**ask yourself at each level:**
+- did i read the error message carefully?
+- did i search for similar issues?
+- did i try a different approach?
+- did i isolate the problem?
+- did i ask for help?
+- did i exhaust every option?
+
+you move to handoff only when you can answer "yes" to all of the above and still cannot proceed.
+
+update your checklist when all tests pass.
+
+---
+
+### step 5: handoff (only if insurmountable)
+
+a handoff is a document that transfers work to your foreman because you hit a wall that is physically impossible to climb alone.
+
+**foreman-only blockers:**
+- credentials only the foreman possesses
+- external access only the foreman can grant
+- approval that requires foreman authority
+
+handoff is the absolute last resort. you must exhaust every option before you consider it.
+
+if you need to emit a handoff:
+
+emit to
+- .behavior/v2026_06_14.fix-keyrack-sso-5/5.3.verification.handoff.v$N.to_foreman.md
+
+**handoff must include:**
+1. what you tried (list every approach you attempted)
+2. why each approach failed (be specific)
+3. what makes this fundamentally impossible without foreman intervention
+4. is this truly a "foreman possesses the key" situation?
+5. rewind instruction: `rhx route.stone.set --stone 5.3.verification --as rewound`
+
+your crew should read your handoff and think: "yes, there was truly no other way."
+
+update your checklist to reference the handoff.

--- a/.behavior/v2026_06_14.fix-keyrack-sso-5/refs/template.[feedback].v1.[given].by_human.md
+++ b/.behavior/v2026_06_14.fix-keyrack-sso-5/refs/template.[feedback].v1.[given].by_human.md
@@ -1,0 +1,27 @@
+emit your response to the feedback into
+- .behavior/v2026_06_14.fix-keyrack-sso-5/$BEHAVIOR_REF_NAME.[feedback].v$FEEDBACK_VERSION.[taken].by_robot.md
+
+1. emit your response checklist
+2. exec your response plan
+3. emit your response checkoffs into the checklist
+
+---
+
+first, bootup your mechanics briefs again
+
+./node_modules/.bin/rhachet roles boot --repo ehmpathy --role mechanic
+
+---
+---
+---
+
+
+# blocker.1
+
+---
+
+# nitpick.2
+
+---
+
+# blocker.3

--- a/.behavior/v2026_06_14.fix-keyrack-sso-5/review/self/.gitignore
+++ b/.behavior/v2026_06_14.fix-keyrack-sso-5/review/self/.gitignore
@@ -1,0 +1,3 @@
+# ignore all self-review files
+*
+!.gitignore

--- a/src/domain.operations/keyrack/adapters/vaults/aws.config/vaultAdapterAwsConfig.ts
+++ b/src/domain.operations/keyrack/adapters/vaults/aws.config/vaultAdapterAwsConfig.ts
@@ -64,9 +64,14 @@ const checkProfileExists = (profileName: string): boolean => {
  * .what = validate sso session for a profile and extract username
  * .why = checks if the profile's sso session is still valid
  *
- * .note = uses `aws configure export-credentials` as primary validator
- *         because it forces credential refresh and validates both SSO and STS in one call
- *         (aws-cli issue #9845 shows get-caller-identity lies via cached credentials)
+ * .note = checks SSO cache expiresAt FIRST because export-credentials can return
+ *         cached STS credentials even when SSO token is expired. this is a documented
+ *         edge case: "SSO credentials have expired but the cached STS credential for
+ *         CLI is still valid, so that aws-cli still appears to work"
+ *         https://github.com/aws/aws-cli/discussions/9237
+ *
+ * .note = uses `aws configure export-credentials` as secondary validator
+ *         only after SSO cache check passes (or if cache is absent)
  *
  * .note = uses `aws sts get-caller-identity` only for username extraction
  *
@@ -75,8 +80,26 @@ const checkProfileExists = (profileName: string): boolean => {
 const validateSsoSession = async (
   profileName: string,
 ): Promise<{ valid: true; username: string } | { valid: false }> => {
-  // validate via export-credentials — forces refresh, validates both SSO and STS
-  // .note = if SSO token is expired, this command fails (can't refresh STS without valid SSO)
+  // check SSO cache expiresAt FIRST — don't trust export-credentials alone
+  // .note = export-credentials can return cached STS creds even when SSO token is expired
+  //         https://github.com/aws/aws-cli/discussions/9237
+  const profileConfig = await getAwsSsoProfileConfig({ profileName });
+  if (profileConfig?.ssoStartUrl) {
+    const ssoCache = previewAwsSsoCacheForDomain({
+      ssoStartUrl: profileConfig.ssoStartUrl,
+    });
+
+    // if SSO token is expired, fail immediately (don't trust export-credentials)
+    if (ssoCache.matched.length > 0) {
+      const expiresAt = ssoCache.matched[0]?.expiresAt;
+      if (expiresAt && new Date(expiresAt) < new Date()) {
+        return { valid: false }; // SSO expired, skip export-credentials
+      }
+    }
+  }
+
+  // SSO cache is valid (or absent) — now validate via export-credentials
+  // .note = if SSO cache is absent, export-credentials will fail if session is truly expired
   // .note = if SSO is valid but STS cache is stale, this command refreshes it
   try {
     await execAsync(


### PR DESCRIPTION
fix(keyrack): check SSO cache expiration before trusting export-credentials

- check SSO cache expiresAt FIRST before calling export-credentials
- export-credentials can return cached STS credentials even when SSO token is expired
- cite aws-cli discussion #9237 documenting this edge case
- prevents false-positive "session valid" when SSO actually expired

---
🐢🌊 surfed in by seaturtle[bot]