### PR TITLE
fix(ci): pin npm@11 for oidc publish to avoid npm@12 node-engine break

### DIFF
--- a/.github/workflows/.publish-npm.yml
+++ b/.github/workflows/.publish-npm.yml
@@ -49,7 +49,7 @@ jobs:
           MIN_VERSION="11.5.1"
           if [ "$(printf '%s\n' "$MIN_VERSION" "$NPM_VERSION" | sort -V | head -n1)" != "$MIN_VERSION" ]; then
             echo "npm $NPM_VERSION < $MIN_VERSION, will upgrade npm now to support oidc..."
-            npm install -g npm@latest
+            npm install -g npm@11
           else
             echo "npm $NPM_VERSION >= $MIN_VERSION, ready to use!"
           fi


### PR DESCRIPTION
fix(ci): pin npm@11 for oidc publish to avoid npm@12 node-engine break

- the publish workflow upgraded npm via `npm install -g npm@latest` to get
  oidc support; npm@latest rolled to 12.0.1 which requires node >=22.22.2,
  but the runner ships node v22.21.0 → EBADENGINE, publish failed.
- pin to `npm@11` (latest 11.x, node-22.21 compatible) which still satisfies
  the MIN_VERSION=11.5.1 oidc requirement.

---
🐢🌊 surfed in by seaturtle[bot]