### PR TITLE
fix(cicd): disable commitlint body-max-line-length for squash-merge bodies

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -2,6 +2,12 @@ module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
     'header-max-length': [1, 'always', 140],
+    // disabled: squash-merge collapses a pr's commits into one body that concatenates
+    // each sub-commit's subject + footers (urls, arns, code refs). those lines routinely
+    // exceed a per-line limit, so config-conventional's error-level body-max-line-length
+    // fails test:commits on the release pr (which lints from the last tag through the
+    // squashed merge commit). headers stay bounded via header-max-length above.
+    'body-max-line-length': [0, 'always', 100],
     'type-enum': [
       2,
       'always',


### PR DESCRIPTION
fix(cicd): disable commitlint body-max-line-length for squash-merge bodies

- squash-merge collapses a pr into one body that concatenates each sub-commit
  subject + footers (urls, arns, refs), which routinely exceed a per-line limit
- config-conventional error-level body-max-line-length then failed test:commits on
  the release pr, which lints from the last tag through the squashed merge commit
  — blocking release despite a fully-green feature
- disable the rule; headers stay bounded via header-max-length

---
🐢🌊 surfed in by seaturtle[bot]