### PR TITLE
fix(cicd): kill unlockKeyrackKeys reap race + widen acceptance shards

### DIFF
--- a/jest.acceptance.shards.jsonc
+++ b/jest.acceptance.shards.jsonc
@@ -1,5 +1,5 @@
 {
   "dynamic": {
-    "shards": 3
+    "shards": 5
   }
 }

--- a/src/domain.operations/keyrack/session/unlockKeyrackKeys.integration.test.ts
+++ b/src/domain.operations/keyrack/session/unlockKeyrackKeys.integration.test.ts
@@ -887,6 +887,19 @@ describe('unlockKeyrackKeys.integration', () => {
     const secretSlowVault = 'slow-vault-secret';
     const keyPair = useBeforeAll(async () => generateAgeKeyPair());
 
+    // idempotent delete: tolerate ENOENT. the daemon reaps its own pid + socket
+    // on SIGTERM, so a check-then-unlink races that self-cleanup — the file can
+    // vanish between existsSync and unlinkSync and throw ENOENT. already-absent
+    // is the desired end state for a delete, so swallow it. this reproduces
+    // deterministically under CI's parallel shards (runs 30901814168 x2).
+    const delIfPresent = (path: string) => {
+      try {
+        unlinkSync(path);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      }
+    };
+
     const reapOwnDaemon = () => {
       const socketPath = getKeyrackDaemonSocketPath({ owner: ownerSlowVault });
       const pidPath = socketPath.replace(/\.sock$/, '.pid');
@@ -897,9 +910,9 @@ describe('unlockKeyrackKeys.integration', () => {
           // allow expected errors: ESRCH = no such process (already dead)
           if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error;
         }
-        unlinkSync(pidPath);
+        delIfPresent(pidPath);
       }
-      if (existsSync(socketPath)) unlinkSync(socketPath);
+      delIfPresent(socketPath);
     };
 
     beforeAll(reapOwnDaemon);


### PR DESCRIPTION
fix(cicd): kill unlockKeyrackKeys reap race + widen acceptance shards

- unlockKeyrackKeys.integration: reapOwnDaemon did a check-then-act
  (existsSync then unguarded unlinkSync) on the daemon pid file. on
  SIGTERM the daemon self-reaps its own pid + socket, so the file
  vanishes between the check and the unlink and throws ENOENT, which
  crashed the whole suite. reproduced deterministically 2/2 in CI
  (run 30901814168, integration shard 3/3). a delIfPresent helper now
  makes both unlinks idempotent (swallow ENOENT, rethrow else) - the
  correct end-state for a delete is already-gone. verified 10/10 local.
- jest.acceptance.shards: 3 -> 5. acceptance shards are the CI critical
  path (slowest ~7m41s of an ~8m10s run); the fattest file is 43s, well
  under a shard budget, so it divides cleanly. more shards cut the
  critical path toward ~5m. integration left at 3 (setup-dominated, so
  more would only add fixed-cost tax).

---
🐢🌊 surfed in by seaturtle[bot]